### PR TITLE
feat: co-list README Auto Update in the marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,6 +20,21 @@
       "source": ".",
       "category": "writing",
       "tags": ["writing", "prose", "voice", "tone", "editing", "anti-slop", "skills", "commands"]
+    },
+    {
+      "name": "readme-auto-update",
+      "description": "Create and refresh evidence-based GitHub profile or project READMEs from repository activity, with free structural templates (icons, badges, table, and more) — no agent or API key. Pairs with Cadence to humanize the prose.",
+      "version": "1.0.1",
+      "author": {
+        "name": "Isabel Wu",
+        "email": "231155141+wuisabel-gif@users.noreply.github.com"
+      },
+      "source": {
+        "source": "github",
+        "repo": "wuisabel-gif/readme-auto-update"
+      },
+      "category": "productivity",
+      "tags": ["readme", "github-profile", "documentation", "skills", "github-action"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -277,6 +277,15 @@ in a new session. New voices you create with `/cadence learn` are written to a
 `voices/` folder in whatever project you're working in. (Developing on Cadence? Point
 the marketplace at a local clone instead: `/plugin marketplace add ~/cadence`.)
 
+**Also in this marketplace: [README Auto Update](https://github.com/wuisabel-gif/readme-auto-update).**
+It builds evidence-based GitHub profile and project READMEs with free structural templates — no
+agent, no API key — and pairs with Cadence: generate the README's structure there, then humanize its
+prose here.
+
+```
+/plugin install readme-auto-update@cadence
+```
+
 `/cadence` not recognized? It runs only in **Claude Code** — not the claude.ai
 website or the desktop app's regular chat. [MANUAL.md](MANUAL.md#1-install--activate)
 covers that and the rest of the activation pitfalls.


### PR DESCRIPTION
Adds **README Auto Update** as a second plugin in this marketplace (sourced from its own repo), so `/plugin marketplace add wuisabel-gif/Cadence` now offers both skills — install with `/plugin install readme-auto-update@cadence`. Also cross-links it from the Install section.

The two pair naturally: README Auto Update builds a GitHub profile/project README's **structure** for free (templates, no agent, no key); Cadence humanizes the **prose**. One marketplace, two complementary skills.

Companion PR on `wuisabel-gif/readme-auto-update` (#13) fixes that plugin's skills path so it loads correctly when installed from here.