### PR TITLE
Reframe product surfaces from AI-detector framing to "catches robotic writing"

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "cadence",
   "metadata": {
-    "description": "Prose fluency for AI harnesses. Write in a voice you choose, with less AI tone."
+    "description": "Prose fluency for any AI agent. Catch robotic-sounding writing and rewrite it in a voice you choose."
   },
   "owner": {
     "name": "Isabel Wu",
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "cadence",
-      "description": "Write in a voice you choose, with less AI tone. One skill, 5 commands (/cadence write, learn, recast, deslop, voices) and a deterministic de-slop detector that scores prose and names every AI tell.",
+      "description": "Catch robotic-sounding writing and rewrite it in a voice you choose. One skill, 5 commands (/cadence write, learn, recast, deslop, voices) and a deterministic checker that scores prose and names every tell.",
       "version": "0.2.0",
       "author": {
         "name": "Isabel Wu",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence",
-  "description": "Write in a voice you choose, with less AI tone. One skill, 5 commands (/cadence write, learn, recast, deslop, voices) and a deterministic de-slop detector that scores prose and names every AI tell.",
+  "description": "Catch robotic-sounding writing and rewrite it in a voice you choose. One skill, 5 commands (/cadence write, learn, recast, deslop, voices) and a deterministic checker that scores prose and names every tell.",
   "version": "0.2.0",
   "author": {
     "name": "Isabel Wu",

--- a/check.html
+++ b/check.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Cadence: score your writing for AI tone</title>
+  <title>Cadence: score how robotic your writing reads</title>
   <meta name="description" content="Paste your writing and see how much it reads like AI. Cadence scores it 0–100 and names every tell. In your browser, nothing sent.">
   <meta property="og:title" content="Cadence: is it you, or does it read like AI?">
   <meta property="og:description" content="Paste anything and see the grade plus every tell. Runs in your browser; nothing is sent.">
@@ -152,7 +152,7 @@
 
   var esc=function(s){return String(s).replace(/[&<>"]/g,function(c){return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'})[c];});};
   var bucket=function(g){return g==='A'||g==='B'?'good':g==='C'?'warn':'bad';};
-  var VERDICT={A:'Reads human.',B:'Mostly human. A couple of tells.',C:'Some AI texture.',D:'Reads machine-made.',F:'Heavy AI slop.'};
+  var VERDICT={A:'Reads human.',B:'Mostly human. A couple of tells.',C:'Some robotic texture.',D:'Reads machine-made.',F:'Heavily robotic.'};
 
   var EXAMPLE="In today's world, finding the right productivity app can be a daunting task. "+
     "Our cutting-edge platform leverages powerful AI to seamlessly streamline your workflow. "+

--- a/extension/assistant.js
+++ b/extension/assistant.js
@@ -219,7 +219,7 @@
           var snips = by[rule].slice(0, 2).map(function (x) { return '“' + esc(x) + '”'; }).join(', ');
           return '<b>' + esc(rule) + '</b> ' + snips;
         }).join('<br>')
-      : '<span class="clean">Reads human. No AI tells.</span>';
+      : '<span class="clean">Reads human. No tells.</span>';
     meter.classList.add('scored');
   }
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest_version": 3,
-  "name": "Cadence: AI-slop detector",
+  "name": "Cadence: robotic-writing checker",
   "version": "0.1.0",
-  "description": "Score any text for AI tone, plus a live impression check and draft-in-your-voice in the Gmail and WhatsApp Web compose box. The score runs locally.",
+  "description": "Score any text for robotic tone, plus a live impression check and draft-in-your-voice in the Gmail and WhatsApp Web compose box. The score runs locally.",
   "action": {
     "default_popup": "popup.html",
-    "default_title": "Cadence: score for AI tone",
+    "default_title": "Cadence: score for robotic tone",
     "default_icon": { "16": "icons/icon-16.png", "48": "icons/icon-48.png", "128": "icons/icon-128.png" }
   },
   "icons": { "16": "icons/icon-16.png", "48": "icons/icon-48.png", "128": "icons/icon-128.png" },

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -11,7 +11,7 @@
     <span class="tag">de-slop</span>
   </header>
 
-  <textarea id="input" placeholder="Paste or type prose to score it for AI tone…" spellcheck="false"></textarea>
+  <textarea id="input" placeholder="Paste or type prose to score it for robotic tone…" spellcheck="false"></textarea>
 
   <div id="readout" class="readout empty" data-grade="">
     <div class="scoreline">

--- a/index.html
+++ b/index.html
@@ -3,11 +3,11 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Cadence: write in a voice you choose, with less AI tone</title>
+<title>Cadence: catch robotic writing, write in a voice you choose</title>
 <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
-<meta name="description" content="Cadence writes in a voice you choose, with less AI tone, in Claude, Codex, Gemini, your browser, or the command line. It learns a voice from writing you admire, writes in it, and runs a deterministic detector that scores any draft and names every AI tell.">
-<meta property="og:title" content="Cadence: write in a voice you choose, with less AI tone">
-<meta property="og:description" content="Write in a voice you choose, with less AI tone. A deterministic detector scores any draft and names every AI tell.">
+<meta name="description" content="Cadence catches writing that sounds robotic and rewrites it in a voice you choose, in Claude, Codex, Gemini, your browser, or the command line. It learns a voice from writing you admire, writes in it, and runs a deterministic checker that scores any draft and names every tell.">
+<meta property="og:title" content="Cadence: catch robotic writing, write in a voice you choose">
+<meta property="og:description" content="Catch writing that sounds robotic and rewrite it in a voice you choose. A deterministic checker scores any draft and names every tell.">
 <meta property="og:type" content="website">
 <script>document.documentElement.classList.remove('no-js');document.documentElement.classList.add('js');</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -341,7 +341,7 @@ section{padding-block:clamp(3.5rem,8vw,7rem)}
   <section class="hero wrap">
     <p class="eyebrow-cmd reveal">cadence · prose fluency for any AI agent or the command line</p>
     <h1 class="reveal" style="margin-top:1rem">Make it sound like you wrote it.</h1>
-    <p class="lede reveal">Cadence learns a voice from writing you admire, then writes in it. Underneath, a deterministic detector scores any draft and names every AI tell, so a clean result is something you check, not just trust.</p>
+    <p class="lede reveal">Cadence learns a voice from writing you admire, then writes in it. Underneath, a deterministic checker scores any draft and names every tell, so a clean result is something you check, not just trust.</p>
     <div class="hero-cta reveal">
       <a class="btn btn-primary" href="check.html">Score your writing →</a>
       <a class="btn btn-ghost" href="#voices">See the voices</a>
@@ -624,7 +624,7 @@ Cadence de-slop  ·  <span style="color:var(--panel-good)">score 0/100  ·  grad
         <tr><td class="c1"><span class="pre">/cadence</span> learn <span class="arg">&lt;sample&gt;</span></td><td class="c2">Reads a book, article, or URL and extracts a reusable voice profile.</td></tr>
         <tr><td class="c1"><span class="pre">/cadence</span> write <span class="arg">&lt;brief&gt;</span></td><td class="c2">Drafts new prose in a chosen voice.</td></tr>
         <tr><td class="c1"><span class="pre">/cadence</span> recast <span class="arg">&lt;text&gt;</span></td><td class="c2">Rewrites existing text into a chosen voice, keeping the meaning.</td></tr>
-        <tr><td class="c1"><span class="pre">/cadence</span> deslop <span class="arg">&lt;text&gt;</span></td><td class="c2">Scores text and reports every AI tell: diagnose, then optionally fix.</td></tr>
+        <tr><td class="c1"><span class="pre">/cadence</span> deslop <span class="arg">&lt;text&gt;</span></td><td class="c2">Scores text and reports every tell: diagnose, then optionally fix.</td></tr>
         <tr><td class="c1"><span class="pre">/cadence</span> voices</td><td class="c2">Lists the voices you've learned plus the shipped seeds.</td></tr>
       </tbody>
     </table>
@@ -651,11 +651,11 @@ Cadence de-slop  ·  <span style="color:var(--panel-good)">score 0/100  ·  grad
       </li>
       <li>
         <span class="date">Jul 3, 2026</span>
-        <span class="entry"><b>Draft replies in your voice, and learn that voice from your posts.</b> The Chrome extension now works in Gmail, WhatsApp Web, Telegram, LinkedIn, Instagram and Facebook: it scores your reply as you type, on-device, and with your own key drafts one in your voice, writing, scoring, then redrafting to clear the AI tells. And “Learn my voice” reads what you've written on the page (your posts on Instagram, Facebook or LinkedIn, or your own sent messages on WhatsApp and Telegram) and distills your sentence-usage traits into that voice.</span>
+        <span class="entry"><b>Draft replies in your voice, and learn that voice from your posts.</b> The Chrome extension now works in Gmail, WhatsApp Web, Telegram, LinkedIn, Instagram and Facebook: it scores your reply as you type, on-device, and with your own key drafts one in your voice, writing, scoring, then redrafting to clear the tells. And “Learn my voice” reads what you've written on the page (your posts on Instagram, Facebook or LinkedIn, or your own sent messages on WhatsApp and Telegram) and distills your sentence-usage traits into that voice.</span>
       </li>
       <li>
         <span class="date">Jun 26, 2026</span>
-        <span class="entry"><b>VS Code extension.</b> Score prose for AI tone in the editor: a live grade in the status bar, the AI tells squiggled inline, and a score-on-demand report. Same detector, generated from the one source. Build with <code>npm run build:vscode</code>.</span>
+        <span class="entry"><b>VS Code extension.</b> Score prose for robotic tone in the editor: a live grade in the status bar, the tells squiggled inline, and a score-on-demand report. Same detector, generated from the one source. Build with <code>npm run build:vscode</code>.</span>
       </li>
       <li>
         <span class="date">Jun 26, 2026</span>
@@ -679,7 +679,7 @@ Cadence de-slop  ·  <span style="color:var(--panel-good)">score 0/100  ·  grad
       </li>
       <li>
         <span class="date">Jun 20, 2026</span>
-        <span class="entry"><b>Chrome extension.</b> Score any text for AI tone right in your browser: popup or right-click. Runs entirely on your machine.</span>
+        <span class="entry"><b>Chrome extension.</b> Score any text for robotic tone right in your browser: popup or right-click. Runs entirely on your machine.</span>
       </li>
       <li>
         <span class="date">Jun 20, 2026</span>

--- a/integrations/gemini/gemini-extension.json
+++ b/integrations/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence",
   "version": "0.1.0",
-  "description": "Write like a human, in a voice you choose, with less AI tone. Includes the deterministic de-slop detector via npx.",
+  "description": "Catch robotic-sounding writing and rewrite it in a voice you choose. Includes the deterministic checker via npx.",
   "contextFileName": "GEMINI.md"
 }

--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cadence-deslop",
-  "displayName": "Cadence: AI-slop detector",
-  "description": "Score prose for AI tone right in the editor. Live grade in the status bar, the AI tells squiggled inline, and a full report on demand. Runs locally, zero dependencies.",
+  "displayName": "Cadence: robotic-writing checker",
+  "description": "Score prose for robotic tone right in the editor. Live grade in the status bar, the tells squiggled inline, and a full report on demand. Runs locally, zero dependencies.",
   "version": "0.2.0",
   "publisher": "cadence",
   "license": "MIT",
@@ -24,12 +24,12 @@
     "commands": [
       {
         "command": "cadence.scoreDocument",
-        "title": "Cadence: Score document for AI tone",
+        "title": "Cadence: Score document for robotic tone",
         "category": "Cadence"
       },
       {
         "command": "cadence.scoreSelection",
-        "title": "Cadence: Score selection for AI tone",
+        "title": "Cadence: Score selection for robotic tone",
         "category": "Cadence"
       }
     ],
@@ -53,7 +53,7 @@
         "cadence.diagnostics.enabled": {
           "type": "boolean",
           "default": true,
-          "description": "Squiggle AI tells (banned phrases, hollow-confidence words, triads, negation pivots, cliché openers) inline as you type."
+          "description": "Squiggle the tells (banned phrases, hollow-confidence words, triads, negation pivots, cliché openers) inline as you type."
         },
         "cadence.proseOnly": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cadence-deslop",
   "version": "0.2.0",
-  "description": "Deterministic AI-slop detector for prose. Scores any text 0–100 and names every AI tell: uniform rhythm, hollow-confidence words, reflexive triads, negation pivots, cliché openers. Zero dependencies. The detector behind the Cadence writing plugin.",
+  "description": "Deterministic checker for robotic-sounding prose. Scores any text 0–100 and names every tell: uniform rhythm, hollow-confidence words, reflexive triads, negation pivots, cliché openers. Zero dependencies. The checker behind the Cadence writing plugin.",
   "type": "module",
   "bin": {
     "cadence-deslop": "skills/cadence/scripts/deslop.mjs",

--- a/skills/cadence/SKILL.md
+++ b/skills/cadence/SKILL.md
@@ -115,7 +115,7 @@ verbatim, then stop and wait for the user to choose. The whole point is to guide
 them to the right command — answer their situation, not a keyword.
 
 ```
-**Cadence** — write in a voice, with less AI tone. What are you working on?
+**Cadence** — write in a voice, and catch writing that sounds robotic. What are you working on?
 
 | If you want to… | Use | Example |
 |---|---|---|


### PR DESCRIPTION
Brings the metadata and marketing surfaces in line with the README reframe already merged in #1. The identity everywhere is now "catches writing that sounds robotic, whoever wrote it," not "AI detector / humanizer."

## Changed (identity + user-facing)
- **Repo description** (set directly, not in this diff)
- **package.json / plugin.json / marketplace.json** descriptions
- **Chrome extension**: manifest name + action title, popup placeholder, clean-result label ("No tells")
- **VS Code**: displayName, description, command titles, squiggle description
- **Gemini** extension description
- **index.html / check.html**: `<title>`, meta + og tags, hero lede, verdict labels, feature entries
- **/cadence skill greeting**

## Deliberately left alone
- **"AI tell" as terminology** in code comments, CONTRIBUTING, GEMINI/AGENTS skill internals. It names a real pattern and reads fine; happy to do a full terminology sweep as a separate PR if you want it.
- **CHANGELOG.md** — a historical record; rewriting past entries would be dishonest.

JSON files validated. Nothing merged; review and merge when it reads right.