### PR TITLE
Document detector scoring and add calibration diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ sentence-usage traits into that voice profile. Build it with
 | [tutorials/scan-a-repo.md](tutorials/scan-a-repo.md) | Tutorial: audit and de-slop an entire repo, then gate it in CI |
 | [extension/README.md](extension/README.md) | The Chrome extension — score prose anywhere, plus a live impression check and draft-in-your-voice in Gmail, WhatsApp Web, Telegram, LinkedIn and Instagram |
 | [integrations/vscode/README.md](integrations/vscode/README.md) | The VS Code extension — live grade, inline tells, and a score report |
+| [SCORING.md](SCORING.md) | Detector scoring formulas, thresholds, grade boundaries, and calibration guidance |
 | [benchmark/README.md](benchmark/README.md) | The accuracy benchmark: labeled corpus, published precision and recall, and the CI gate |
 | [lora/README.md](lora/README.md) | LoRA-Cadence: train a slop-humanizing QLoRA graded by the detector, plus the Kaggle notebook |
 | [PHILOSOPHY.md](PHILOSOPHY.md) | The thinking behind it — *The Age of Taste* |

--- a/SCORING.md
+++ b/SCORING.md
@@ -1,0 +1,82 @@
+# Cadence scoring model
+
+Cadence reports a deterministic score from 0 to 100. The score is a transparent
+heuristic for editing feedback, not a probability that text was written by an AI
+and not a scientific measurement of authorship. The current constants are design
+choices protected by the benchmark; they are not presented as statistically
+proven thresholds.
+
+## Lexical findings
+
+Each finding contributes one severity weight:
+
+| Severity | Points | Current use |
+| --- | ---: | --- |
+| High | 6 | Banned phrases and negation pivots |
+| Medium | 4 | Hollow-confidence words |
+| Low | 2 | Triads, hedge stacking, and cliché openers |
+
+A finding is counted each time its detector matches. The score starts at zero and
+adds the weights for all findings.
+
+## Structural contributions
+
+Structural rates are normalized per 100 words unless noted otherwise.
+
+| Signal | Activation | Contribution |
+| --- | --- | --- |
+| Uniform rhythm | At least 5 sentences and sentence-length CV `< 0.4` | `round((0.4 - CV) * 60)` |
+| Adverbs | Adverb rate `> 5` | `round((rate - 5) * 2)` |
+| Em dashes | Em-dash rate `> 2.5` | `round((rate - 2.5) * 3)` |
+| Triad density | Triad findings / sentence count `> 0.25` | `round((density - 0.25) * 40)` |
+
+The sentence-length coefficient of variation is standard deviation divided by
+mean sentence length. A low value means sentence lengths cluster closely. The
+minimum sentence count prevents a short passage from being judged on rhythm alone.
+
+After all contributions are added, the result is rounded and clamped to the range
+0–100. A threshold is only applied when the relevant structural condition is met;
+there is no structural contribution on the other side of the threshold.
+
+## Grades
+
+| Score | Grade |
+| ---: | :--- |
+| 0–10 | A |
+| 11–25 | B |
+| 26–45 | C |
+| 46–70 | D |
+| 71–100 | F |
+
+These boundaries are product-facing editing bands, not externally validated
+quality standards. In particular, the benchmark's default classification rule is
+`score > 10`, which treats text above the A band as flagged for evaluation. The
+CLI's `--strict` mode uses a separate default gate of 25. Neither cutoff changes
+the score itself.
+
+## Worked example
+
+Suppose a passage has two high-severity findings, one medium finding, and two low
+findings. Its lexical subtotal is:
+
+$$
+2(6) + 1(4) + 2(2) = 20
+$$
+
+If its sentence-length CV is `0.30` across at least five sentences, uniform rhythm
+adds `round((0.4 - 0.30) * 60) = 6`, for a score of 26 before any other structural
+terms. The grade is C. This example illustrates the arithmetic; it does not claim
+that these constants are optimal. A real passage can trigger more than one lexical
+detector, so its final score may be higher than the subtotal illustrated here.
+
+## Calibration and interpretation
+
+Cadence is intentionally precision-first: a high score names visible patterns for
+an editor to inspect, while a low score does not prove that prose is human. The
+checked-in benchmark is a small, labeled regression corpus. It reports uncertainty
+and should be treated as a sanity check rather than a validated authorship test.
+
+When changing a weight or threshold, contributors should run the benchmark before
+and after the change, inspect human false positives and missed AI samples, and
+explain the tradeoff in the pull request. Detector behavior should not change just
+because a constant looks more aesthetically pleasing.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,6 +4,11 @@ How well does Cadence's score separate human writing from AI output? This
 directory measures it and publishes the numbers, so the claim isn't just "trust
 us."
 
+The scoring arithmetic and the distinction between grades, benchmark cutoffs,
+and CLI strict mode are documented in [SCORING.md](../SCORING.md). The benchmark
+also reports score distributions and sample-level lexical rule diagnostics so
+threshold changes can be reviewed without treating the detector as ground truth.
+
 ```
 npm run bench          # human-readable report + threshold sweep
 npm run bench:check     # CI gate: fails if recall or specificity drops

--- a/benchmark/bench.mjs
+++ b/benchmark/bench.mjs
@@ -45,6 +45,28 @@ function wilson(k, n) {
 }
 const ci = (k, n) => { const [lo, hi] = wilson(k, n); return `95% CI ${pct(lo)}-${pct(hi)}%`; };
 
+// Diagnostics are sample-level: a rule that fires three times in one sample
+// still counts as one sample containing that rule. This keeps per-rule rates
+// comparable across rules with different numbers of findings.
+const corpusHuman = corpus.filter((s) => s.label === 'human').length;
+const corpusAI = corpus.filter((s) => s.label === 'ai').length;
+const RULES = [...new Set(scored.flatMap((s) => s.r.findings.map((f) => f.rule)))].sort();
+const scoreSummary = (label) => {
+  const values = scored.filter((s) => !label || s.label === label).map((s) => s.r.score).sort((a, b) => a - b);
+  if (!values.length) return { samples: 0, min: 0, max: 0, mean: 0, median: 0 };
+  const mid = Math.floor(values.length / 2);
+  const median = values.length % 2 ? values[mid] : (values[mid - 1] + values[mid]) / 2;
+  return { samples: values.length, min: values[0], max: values.at(-1), mean: +(values.reduce((sum, x) => sum + x, 0) / values.length).toFixed(1), median };
+};
+const scoreDistributions = Object.fromEntries(['human', 'ai'].map((label) => [label, scoreSummary(label)]));
+const ruleDiagnostics = RULES.map((rule) => {
+  const samples = scored.filter((s) => s.r.findings.some((f) => f.rule === rule));
+  const human = samples.filter((s) => s.label === 'human').length;
+  const ai = samples.filter((s) => s.label === 'ai').length;
+  return { rule, samples: samples.length, human, ai,
+    humanRate: +(human / (corpusHuman || 1)).toFixed(3), aiRate: +(ai / (corpusAI || 1)).toFixed(3) };
+});
+
 // Confusion counts + derived metrics for a given "flag when score > threshold" cut.
 function scoreAt(threshold) {
   let tp = 0, fp = 0, tn = 0, fn = 0;
@@ -75,7 +97,7 @@ const metrics = {
   recall: +recall.toFixed(3), recallCI: wilson(tp, nAI).map((x) => +x.toFixed(3)),
   specificity: +specificity.toFixed(3), specificityCI: wilson(tn, nHuman).map((x) => +x.toFixed(3)),
   fpr: +fpr.toFixed(3), precision: +precision.toFixed(3), f1: +f1.toFixed(3),
-  accuracy: +accuracy.toFixed(3), confusion: { tp, fp, tn, fn },
+  accuracy: +accuracy.toFixed(3), confusion: { tp, fp, tn, fn }, scoreDistributions, ruleDiagnostics,
 };
 
 if (args.includes('--json')) {
@@ -90,6 +112,15 @@ if (args.includes('--json')) {
   L.push(`precision                 ${pct(precision)}%`);
   L.push(`F1                        ${pct(f1)}%`);
   L.push(`accuracy                  ${pct(accuracy)}%`);
+  L.push('score distribution:');
+  for (const label of ['human', 'ai']) {
+    const d = scoreDistributions[label];
+    L.push(`  ${label.padEnd(6)} min ${String(d.min).padStart(3)}  median ${String(d.median).padStart(4)}  mean ${d.mean.toFixed(1).padStart(5)}  max ${String(d.max).padStart(3)}`);
+  }
+  L.push('rule diagnostics (human rate / AI rate):');
+  for (const d of ruleDiagnostics) {
+    L.push(`  ${d.rule.padEnd(20)} ${(d.humanRate * 100).toFixed(1)}% / ${(d.aiRate * 100).toFixed(1)}%`);
+  }
   L.push('─'.repeat(58));
   const misses = rows.filter((r) => !r.correct);
   if (misses.length) {

--- a/package.json
+++ b/package.json
@@ -11,18 +11,19 @@
   "files": [
     "skills/cadence/scripts/deslop.mjs",
     "skills/cadence/scripts/extract-text.mjs",
+    "SCORING.md",
     "README.md",
     "LICENSE"
   ],
   "scripts": {
-    "test": "node --test tests/deslop.test.mjs tests/extract-text.test.mjs tests/extension.test.mjs tests/vscode.test.mjs",
+    "test": "node --test tests/deslop.test.mjs tests/extract-text.test.mjs tests/extension.test.mjs tests/vscode.test.mjs tests/benchmark.test.mjs",
     "deslop": "node skills/cadence/scripts/deslop.mjs",
     "bench": "node benchmark/bench.mjs",
     "bench:check": "node benchmark/bench.mjs --check",
     "build:extension": "node scripts/build-extension.mjs",
     "build:vscode": "node scripts/build-vscode.mjs",
     "build:claude-skill": "node scripts/build-claude-skill.mjs",
-    "check:docs": "node skills/cadence/scripts/deslop.mjs --prose-only --max 10 README.md && node skills/cadence/scripts/deslop.mjs --prose-only --max 10 CONTRIBUTING.md && node skills/cadence/scripts/deslop.mjs --prose-only --max 15 PHILOSOPHY.md && node skills/cadence/scripts/deslop.mjs --prose-only --max 10 CHANGELOG.md && node skills/cadence/scripts/deslop.mjs --prose-only --max 12 MANUAL.md && node skills/cadence/scripts/deslop.mjs --prose-only --max 10 tutorials/scan-a-repo.md"
+    "check:docs": "node skills/cadence/scripts/deslop.mjs --prose-only --max 10 README.md && node skills/cadence/scripts/deslop.mjs --prose-only --max 10 CONTRIBUTING.md && node skills/cadence/scripts/deslop.mjs --prose-only --max 15 PHILOSOPHY.md && node skills/cadence/scripts/deslop.mjs --prose-only --max 10 CHANGELOG.md && node skills/cadence/scripts/deslop.mjs --prose-only --max 12 MANUAL.md && node skills/cadence/scripts/deslop.mjs --prose-only --max 10 tutorials/scan-a-repo.md && node skills/cadence/scripts/deslop.mjs --prose-only --max 10 SCORING.md"
   },
   "keywords": [
     "ai-slop", "ai-detector", "ai-humanizer", "humanize-ai-text", "ai-writing",

--- a/tests/benchmark.test.mjs
+++ b/tests/benchmark.test.mjs
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const corpus = JSON.parse(readFileSync(new URL('../benchmark/corpus.json', import.meta.url), 'utf8'));
+const expectedHuman = corpus.filter((sample) => sample.label === 'human').length;
+const expectedAI = corpus.filter((sample) => sample.label === 'ai').length;
+
+test('benchmark JSON exposes stable calibration diagnostics', () => {
+  const output = execFileSync(process.execPath, ['benchmark/bench.mjs', '--json'], { encoding: 'utf8' });
+  const { metrics } = JSON.parse(output);
+
+  assert.equal(metrics.samples, corpus.length);
+  assert.equal(metrics.human, expectedHuman);
+  assert.equal(metrics.ai, expectedAI);
+  assert.equal(metrics.confusion.tp + metrics.confusion.fp + metrics.confusion.tn + metrics.confusion.fn, metrics.samples);
+  assert.equal(metrics.scoreDistributions.human.samples, metrics.human);
+  assert.equal(metrics.scoreDistributions.ai.samples, metrics.ai);
+
+  for (const diagnostic of metrics.ruleDiagnostics) {
+    assert.ok(diagnostic.rule || diagnostic.signal);
+    assert.ok(diagnostic.human >= 0 && diagnostic.ai >= 0);
+    assert.ok(diagnostic.humanRate >= 0 && diagnostic.humanRate <= 1);
+    assert.ok(diagnostic.aiRate >= 0 && diagnostic.aiRate <= 1);
+  }
+});


### PR DESCRIPTION
## Summary

Closes #8.

- Adds `SCORING.md` with the detector's lexical weights, structural formulas, thresholds, grade boundaries, and cutoff distinctions.
- Extends benchmark output with human/AI score summaries and sample-level lexical rule diagnostics in human-readable and JSON modes.
- Adds benchmark regression coverage and includes the scoring document in the npm package and documentation checks.

## Baseline

Detector scoring behavior and default benchmark results are unchanged. This PR adds documentation and diagnostics only; it does not recalibrate weights or thresholds.

Current checked-in baseline remains:

- 48 samples: 24 human, 24 AI
- Precision: 90.9%
- Recall: 41.7%
- Specificity: 95.8%
- F1: 57.1%
- Accuracy: 68.8%

The new diagnostics are intended to support future review, not to treat this small corpus or the detector itself as ground truth.

## Verification

- `npm test` — 37 passing
- `npm run bench:check` — passing
- `npm run check:docs` — passing
- `npm pack --dry-run` — includes `SCORING.md`
- `git diff --check` — clean
