### PR TITLE
Harden sentence splitting for ellipses and terminal punctuation

### DIFF
--- a/extension/detector.js
+++ b/extension/detector.js
@@ -70,7 +70,7 @@ function splitSentences(text) {
   const tokens = cleaned.split(/(\s+)/);
   for (let i = 0; i < tokens.length; i++) {
     buf += tokens[i];
-    const m = tokens[i].match(/([.!?]+)["')\]]?$/);
+    const m = tokens[i].match(/([.!?…]+)["')\]]?$/);
     if (m) {
       const word = tokens[i].replace(/[.!?"')\]]+$/, '').toLowerCase();
       const lastWord = word.split(/[^a-z.]/).pop();

--- a/integrations/vscode/detector.js
+++ b/integrations/vscode/detector.js
@@ -69,7 +69,7 @@ function splitSentences(text) {
   const tokens = cleaned.split(/(\s+)/);
   for (let i = 0; i < tokens.length; i++) {
     buf += tokens[i];
-    const m = tokens[i].match(/([.!?]+)["')\]]?$/);
+    const m = tokens[i].match(/([.!?…]+)["')\]]?$/);
     if (m) {
       const word = tokens[i].replace(/[.!?"')\]]+$/, '').toLowerCase();
       const lastWord = word.split(/[^a-z.]/).pop();

--- a/skills/cadence/scripts/deslop.mjs
+++ b/skills/cadence/scripts/deslop.mjs
@@ -92,7 +92,7 @@ export function splitSentences(text) {
   const tokens = cleaned.split(/(\s+)/);
   for (let i = 0; i < tokens.length; i++) {
     buf += tokens[i];
-    const m = tokens[i].match(/([.!?]+)["')\]]?$/);
+    const m = tokens[i].match(/([.!?…]+)["')\]]?$/);
     if (m) {
       const word = tokens[i].replace(/[.!?"')\]]+$/, '').toLowerCase();
       const lastWord = word.split(/[^a-z.]/).pop();

--- a/tests/deslop.test.mjs
+++ b/tests/deslop.test.mjs
@@ -70,6 +70,19 @@ test('sentence splitter respects abbreviations', () => {
   assert.equal(s.length, 2, `expected 2 sentences, got ${s.length}: ${JSON.stringify(s)}`);
 });
 
+test('sentence splitter handles ellipses, decimals, and terminal punctuation', () => {
+  const cases = [
+    ['Wait... Really? Yes.', 3],
+    ['He paused… Then left.', 2],
+    ['The value is 3.14. Next value.', 2],
+    ['She said "Done." Next step.', 2],
+    ['Really?! Yes.', 2],
+  ];
+  for (const [input, expected] of cases) {
+    assert.equal(splitSentences(input).length, expected, `${input} should split into ${expected} sentences`);
+  }
+});
+
 test('applyFixes swaps hollow words, deletes throat-clears, keeps grammar', () => {
   const src = "In today's world, we leverage robust tools. It's worth noting that this is comprehensive.";
   const r = analyze(src);


### PR DESCRIPTION
## Summary

- Add regression coverage for ellipses, decimals, closing quotes, and mixed terminal punctuation.
- Recognize Unicode ellipses as sentence terminators without changing decimal handling.

## Verification

- `npm test` passes.