### PR TITLE
Expose exact analyzer score breakdown

### DIFF
--- a/SCORING.md
+++ b/SCORING.md
@@ -19,6 +19,11 @@ Each finding contributes one severity weight:
 A finding is counted each time its detector matches. The score starts at zero and
 adds the weights for all findings.
 
+The programmatic result also exposes `breakdown.lexical` with the high, medium,
+and low subtotals, plus `breakdown.structural` with one contribution per signal.
+Their totals sum to `breakdown.total`, which is the returned score after the
+0–100 clamp.
+
 ## Structural contributions
 
 Structural rates are normalized per 100 words unless noted otherwise.

--- a/extension/detector.js
+++ b/extension/detector.js
@@ -220,14 +220,24 @@ function analyze(rawText) {
   const uniformRhythm = sentences.length >= 5 && lengthCV < 0.4;
 
   // ── Transparent score: 0 (clean) … 100 (heavy slop) ──
+  const breakdown = {
+    lexical: { high: 0, med: 0, low: 0, total: 0 },
+    structural: { uniformRhythm: 0, adverbs: 0, emDashes: 0, triads: 0, total: 0 },
+  };
   let score = 0;
   for (const f of findings) {
-    score += f.severity === 'high' ? 6 : f.severity === 'med' ? 4 : 2;
+    const points = f.severity === 'high' ? 6 : f.severity === 'med' ? 4 : 2;
+    breakdown.lexical[f.severity] += points;
+    breakdown.lexical.total += points;
+    score += points;
   }
-  if (uniformRhythm) score += Math.round((0.4 - lengthCV) * 60); // up to +24
-  if (adverbRate > 5) score += Math.round((adverbRate - 5) * 2);
-  if (emDashRate > 2.5) score += Math.round((emDashRate - 2.5) * 3);
-  if (triadDensity > 0.25) score += Math.round((triadDensity - 0.25) * 40);
+  if (uniformRhythm) breakdown.structural.uniformRhythm = Math.round((0.4 - lengthCV) * 60); // up to +24
+  if (adverbRate > 5) breakdown.structural.adverbs = Math.round((adverbRate - 5) * 2);
+  if (emDashRate > 2.5) breakdown.structural.emDashes = Math.round((emDashRate - 2.5) * 3);
+  if (triadDensity > 0.25) breakdown.structural.triads = Math.round((triadDensity - 0.25) * 40);
+  breakdown.structural.total = Object.values(breakdown.structural).reduce((sum, points) => sum + points, 0) - breakdown.structural.total;
+  score += breakdown.structural.total;
+  breakdown.total = breakdown.lexical.total + breakdown.structural.total;
   score = Math.max(0, Math.min(100, Math.round(score)));
 
   const grade = score <= 10 ? 'A' : score <= 25 ? 'B' : score <= 45 ? 'C' : score <= 70 ? 'D' : 'F';
@@ -235,6 +245,7 @@ function analyze(rawText) {
   return {
     score,
     grade,
+    breakdown,
     metrics: {
       words: wordCount,
       sentences: sentences.length,

--- a/integrations/vscode/detector.js
+++ b/integrations/vscode/detector.js
@@ -219,14 +219,24 @@ function analyze(rawText) {
   const uniformRhythm = sentences.length >= 5 && lengthCV < 0.4;
 
   // ── Transparent score: 0 (clean) … 100 (heavy slop) ──
+  const breakdown = {
+    lexical: { high: 0, med: 0, low: 0, total: 0 },
+    structural: { uniformRhythm: 0, adverbs: 0, emDashes: 0, triads: 0, total: 0 },
+  };
   let score = 0;
   for (const f of findings) {
-    score += f.severity === 'high' ? 6 : f.severity === 'med' ? 4 : 2;
+    const points = f.severity === 'high' ? 6 : f.severity === 'med' ? 4 : 2;
+    breakdown.lexical[f.severity] += points;
+    breakdown.lexical.total += points;
+    score += points;
   }
-  if (uniformRhythm) score += Math.round((0.4 - lengthCV) * 60); // up to +24
-  if (adverbRate > 5) score += Math.round((adverbRate - 5) * 2);
-  if (emDashRate > 2.5) score += Math.round((emDashRate - 2.5) * 3);
-  if (triadDensity > 0.25) score += Math.round((triadDensity - 0.25) * 40);
+  if (uniformRhythm) breakdown.structural.uniformRhythm = Math.round((0.4 - lengthCV) * 60); // up to +24
+  if (adverbRate > 5) breakdown.structural.adverbs = Math.round((adverbRate - 5) * 2);
+  if (emDashRate > 2.5) breakdown.structural.emDashes = Math.round((emDashRate - 2.5) * 3);
+  if (triadDensity > 0.25) breakdown.structural.triads = Math.round((triadDensity - 0.25) * 40);
+  breakdown.structural.total = Object.values(breakdown.structural).reduce((sum, points) => sum + points, 0) - breakdown.structural.total;
+  score += breakdown.structural.total;
+  breakdown.total = breakdown.lexical.total + breakdown.structural.total;
   score = Math.max(0, Math.min(100, Math.round(score)));
 
   const grade = score <= 10 ? 'A' : score <= 25 ? 'B' : score <= 45 ? 'C' : score <= 70 ? 'D' : 'F';
@@ -234,6 +244,7 @@ function analyze(rawText) {
   return {
     score,
     grade,
+    breakdown,
     metrics: {
       words: wordCount,
       sentences: sentences.length,

--- a/skills/cadence/scripts/deslop.mjs
+++ b/skills/cadence/scripts/deslop.mjs
@@ -242,14 +242,24 @@ export function analyze(rawText) {
   const uniformRhythm = sentences.length >= 5 && lengthCV < 0.4;
 
   // ── Transparent score: 0 (clean) … 100 (heavy slop) ──
+  const breakdown = {
+    lexical: { high: 0, med: 0, low: 0, total: 0 },
+    structural: { uniformRhythm: 0, adverbs: 0, emDashes: 0, triads: 0, total: 0 },
+  };
   let score = 0;
   for (const f of findings) {
-    score += f.severity === 'high' ? 6 : f.severity === 'med' ? 4 : 2;
+    const points = f.severity === 'high' ? 6 : f.severity === 'med' ? 4 : 2;
+    breakdown.lexical[f.severity] += points;
+    breakdown.lexical.total += points;
+    score += points;
   }
-  if (uniformRhythm) score += Math.round((0.4 - lengthCV) * 60); // up to +24
-  if (adverbRate > 5) score += Math.round((adverbRate - 5) * 2);
-  if (emDashRate > 2.5) score += Math.round((emDashRate - 2.5) * 3);
-  if (triadDensity > 0.25) score += Math.round((triadDensity - 0.25) * 40);
+  if (uniformRhythm) breakdown.structural.uniformRhythm = Math.round((0.4 - lengthCV) * 60); // up to +24
+  if (adverbRate > 5) breakdown.structural.adverbs = Math.round((adverbRate - 5) * 2);
+  if (emDashRate > 2.5) breakdown.structural.emDashes = Math.round((emDashRate - 2.5) * 3);
+  if (triadDensity > 0.25) breakdown.structural.triads = Math.round((triadDensity - 0.25) * 40);
+  breakdown.structural.total = Object.values(breakdown.structural).reduce((sum, points) => sum + points, 0) - breakdown.structural.total;
+  score += breakdown.structural.total;
+  breakdown.total = breakdown.lexical.total + breakdown.structural.total;
   score = Math.max(0, Math.min(100, Math.round(score)));
 
   const grade = score <= 10 ? 'A' : score <= 25 ? 'B' : score <= 45 ? 'C' : score <= 70 ? 'D' : 'F';
@@ -257,6 +267,7 @@ export function analyze(rawText) {
   return {
     score,
     grade,
+    breakdown,
     metrics: {
       words: wordCount,
       sentences: sentences.length,

--- a/tests/deslop.test.mjs
+++ b/tests/deslop.test.mjs
@@ -38,6 +38,16 @@ test('slop scores strictly worse than human', () => {
   assert.ok(analyze(SLOP).score > analyze(HUMAN).score);
 });
 
+test('score breakdown sums to the deterministic score', () => {
+  const r = analyze(SLOP);
+  assert.equal(r.breakdown.total, r.score);
+  assert.equal(r.breakdown.lexical.total,
+    r.breakdown.lexical.high + r.breakdown.lexical.med + r.breakdown.lexical.low);
+  assert.equal(r.breakdown.structural.total,
+    r.breakdown.structural.uniformRhythm + r.breakdown.structural.adverbs
+    + r.breakdown.structural.emDashes + r.breakdown.structural.triads);
+});
+
 test('catches banned phrases', () => {
   const r = analyze(SLOP);
   const banned = r.findings.filter((f) => f.rule === 'banned-phrase');


### PR DESCRIPTION
## Summary

- Add lexical and structural score contributions to `analyze()` results.
- Keep the existing score, grade, and detector behavior unchanged.
- Regenerate extension and VS Code detector bundles from the shared source.
- Document the new breakdown and add invariant tests.

## Verification

- `npm test` passes.
- `npm run build:extension` passes.
- `npm run build:vscode` passes.