### PR TITLE
Document regression and held-out evaluation protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ sentence-usage traits into that voice profile. Build it with
 | [integrations/vscode/README.md](integrations/vscode/README.md) | The VS Code extension — live grade, inline tells, and a score report |
 | [SCORING.md](SCORING.md) | Detector scoring formulas, thresholds, grade boundaries, and calibration guidance |
 | [benchmark/README.md](benchmark/README.md) | The accuracy benchmark: labeled corpus, published precision and recall, and the CI gate |
+| [benchmark/EVALUATION.md](benchmark/EVALUATION.md) | Evaluation protocol for regression fixtures, provenance, leakage, and held-out data |
 | [lora/README.md](lora/README.md) | LoRA-Cadence: train a slop-humanizing QLoRA graded by the detector, plus the Kaggle notebook |
 | [PHILOSOPHY.md](PHILOSOPHY.md) | The thinking behind it — *The Age of Taste* |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | How the project is built and how to add a rule, voice, or command |

--- a/benchmark/EVALUATION.md
+++ b/benchmark/EVALUATION.md
@@ -1,0 +1,63 @@
+# Benchmark evaluation protocol
+
+Cadence has two different benchmark needs. They should not be conflated.
+
+## Regression corpus
+
+`benchmark/corpus.json` is the small, checked-in regression corpus used by
+`npm run bench:check`. It protects detector behavior from accidental changes. Its
+labels and text are part of the repository, so changes to it can change the CI
+baseline. Keep this corpus small, attributable, and stable.
+
+Each record should include:
+
+- A stable `id`
+- A `label` of `human` or `ai`
+- A short `note` describing the register or fixture purpose
+- `source` or provenance when the text is not original to the repository
+- Domain/register metadata when practical
+
+The regression corpus is not a blind evaluation and must not be described as proof
+that Cadence identifies authorship.
+
+## Held-out evaluation
+
+A future evaluation set should be kept outside the training and rule-development
+loop. It should not be used to select detector phrases, weights, thresholds, grade
+boundaries, or LoRA targets. Report the version, collection date, provenance,
+license, domain, language, and generation model or authorship process where known.
+
+At minimum, report:
+
+- Sample counts by label, domain, and register
+- Precision, recall, specificity, F1, and accuracy
+- Confusion matrix and confidence intervals
+- Score distributions by label
+- False positives and missed AI samples, with identifiers but without publishing
+  restricted text
+- The threshold selected before evaluation
+
+If samples are derived from prompts or source documents, split by prompt/source
+before evaluation. Otherwise near-duplicates can leak between development and test
+sets and make results look stronger than they are.
+
+## Metadata validation
+
+Before adding or evaluating corpus records, check that every record has a stable
+identifier, an allowed label, non-empty text, and provenance metadata appropriate to
+its license. Record whether text is original, public domain, user-contributed, or
+reproduced under a dataset license. Do not redistribute text when the source terms
+do not permit it.
+
+A detector score is an observation produced by the system under evaluation. It is
+not ground truth. Using Cadence's own score as the sole label, filter, or evaluation
+criterion would be circular and could reward the detector for agreeing with itself.
+
+## Recommended sequence
+
+1. Freeze a development set and a separately controlled held-out set.
+2. Record provenance and license terms before processing text.
+3. Select rules and thresholds using development data only.
+4. Run one untouched held-out evaluation and preserve the exact report.
+5. Add only deliberately chosen, licensed regression fixtures to the repository.
+6. Repeat the protocol when the corpus, detector, or generation domains change.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -8,6 +8,8 @@ The scoring arithmetic and the distinction between grades, benchmark cutoffs,
 and CLI strict mode are documented in [SCORING.md](../SCORING.md). The benchmark
 also reports score distributions and sample-level lexical rule diagnostics so
 threshold changes can be reviewed without treating the detector as ground truth.
+The proposed separation between regression fixtures and held-out evaluation is
+documented in [EVALUATION.md](EVALUATION.md).
 
 ```
 npm run bench          # human-readable report + threshold sweep


### PR DESCRIPTION
## Summary

- Document the distinction between the checked-in regression corpus and future held-out evaluation.
- Define provenance, licensing, metadata, leakage, and reporting requirements.
- Explicitly avoid circular evaluation using Cadence scores as ground truth.

## Verification

- Documentation-only change.
- Existing benchmark behavior is unchanged.