### PR TITLE
Add graceful limits for oversized analyzer input

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -178,6 +178,11 @@ No voice fits? Learn your own (§3).
 
 The detector on its own. Pure Node, zero dependencies. Run it three ways:
 
+CLI input is limited to 5 MiB per file, stdin stream, or extracted document. This
+prevents accidental multi-megabyte scans from consuming unbounded memory. URLs
+are subject to the extractor's own response handling as well as the analyzer
+limit.
+
 ```bash
 npx cadence-deslop <file>            # no install
 node skills/cadence/scripts/deslop.mjs <file>   # from a clone
@@ -218,6 +223,7 @@ cat draft.txt | cadence-deslop       # from stdin
 | `0` | Ran (and, under `--strict`/`--max`, stayed within the limit). |
 | `1` | `--strict`/`--max` threshold exceeded. |
 | `3` | A `.pdf`/`.docx`/URL produced no readable text (convert it to `.txt`). |
+| `2` | Input exceeded the 5 MiB limit or a `--max` value was invalid. |
 
 ### Examples
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -181,7 +181,7 @@ The detector on its own. Pure Node, zero dependencies. Run it three ways:
 CLI input is limited to 5 MiB per file, stdin stream, or extracted document. This
 prevents accidental multi-megabyte scans from consuming unbounded memory. URLs
 are subject to the extractor's own response handling as well as the analyzer
-limit.
+limit; the limit is checked after the response is received.
 
 ```bash
 npx cadence-deslop <file>            # no install

--- a/README.md
+++ b/README.md
@@ -383,7 +383,6 @@ sentence-usage traits into that voice profile. Build it with
 | [extension/README.md](extension/README.md) | The Chrome extension — score prose anywhere, plus a live impression check and draft-in-your-voice in Gmail, WhatsApp Web, Telegram, LinkedIn and Instagram |
 | [integrations/vscode/README.md](integrations/vscode/README.md) | The VS Code extension — live grade, inline tells, and a score report |
 | [SCORING.md](SCORING.md) | Detector scoring formulas, thresholds, grade boundaries, and calibration guidance |
-| [MANUAL.md](MANUAL.md) | CLI usage, including the 5 MiB input limit |
 | [benchmark/README.md](benchmark/README.md) | The accuracy benchmark: labeled corpus, published precision and recall, and the CI gate |
 | [lora/README.md](lora/README.md) | LoRA-Cadence: train a slop-humanizing QLoRA graded by the detector, plus the Kaggle notebook |
 | [PHILOSOPHY.md](PHILOSOPHY.md) | The thinking behind it — *The Age of Taste* |

--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ sentence-usage traits into that voice profile. Build it with
 | [extension/README.md](extension/README.md) | The Chrome extension — score prose anywhere, plus a live impression check and draft-in-your-voice in Gmail, WhatsApp Web, Telegram, LinkedIn and Instagram |
 | [integrations/vscode/README.md](integrations/vscode/README.md) | The VS Code extension — live grade, inline tells, and a score report |
 | [SCORING.md](SCORING.md) | Detector scoring formulas, thresholds, grade boundaries, and calibration guidance |
+| [MANUAL.md](MANUAL.md) | CLI usage, including the 5 MiB input limit |
 | [benchmark/README.md](benchmark/README.md) | The accuracy benchmark: labeled corpus, published precision and recall, and the CI gate |
 | [lora/README.md](lora/README.md) | LoRA-Cadence: train a slop-humanizing QLoRA graded by the detector, plus the Kaggle notebook |
 | [PHILOSOPHY.md](PHILOSOPHY.md) | The thinking behind it — *The Age of Taste* |

--- a/extension/detector.js
+++ b/extension/detector.js
@@ -44,6 +44,13 @@ const HEDGES = [
   'it could be argued', 'one could say',
 ];
 
+const MAX_INPUT_BYTES = 5 * 1024 * 1024;
+
+function assertInputSize(text, label = 'input') {
+  const bytes = Buffer.byteLength(text, 'utf8');
+  if (bytes > MAX_INPUT_BYTES) throw new RangeError(`${label} exceeds the ${MAX_INPUT_BYTES / (1024 * 1024)} MiB limit`);
+}
+
 // Word-boundary matchers so "usually" inside "unusually" (or "might" inside
 // "mighty", "often" inside "soften") doesn't register as a hedge.
 const HEDGE_RES = HEDGES.map((h) => new RegExp(`\\b${h.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`));

--- a/extension/detector.js
+++ b/extension/detector.js
@@ -183,6 +183,7 @@ function detectClicheOpeners(sentences) {
 
 // ─── Main analysis ──────────────────────────────────────────────────────────
 function analyze(rawText) {
+  assertInputSize(String(rawText));
   // Normalize typographic quotes once, before any detector runs, so curly-quote
   // prose (and stripHtml's decoded &rsquo;) matches the same rules as ASCII text.
   const text = normalizeQuotes(rawText);

--- a/extension/detector.js
+++ b/extension/detector.js
@@ -46,8 +46,15 @@ const HEDGES = [
 
 const MAX_INPUT_BYTES = 5 * 1024 * 1024;
 
+function utf8ByteLength(text) {
+  if (typeof TextEncoder !== 'undefined') return new TextEncoder().encode(text).length;
+  let bytes = 0;
+  for (const cp of text) bytes += cp.codePointAt(0) <= 0x7f ? 1 : cp.codePointAt(0) <= 0x7ff ? 2 : cp.codePointAt(0) <= 0xffff ? 3 : 4;
+  return bytes;
+}
+
 function assertInputSize(text, label = 'input') {
-  const bytes = Buffer.byteLength(text, 'utf8');
+  const bytes = utf8ByteLength(text);
   if (bytes > MAX_INPUT_BYTES) throw new RangeError(`${label} exceeds the ${MAX_INPUT_BYTES / (1024 * 1024)} MiB limit`);
 }
 

--- a/integrations/vscode/detector.js
+++ b/integrations/vscode/detector.js
@@ -43,6 +43,13 @@ const HEDGES = [
   'it could be argued', 'one could say',
 ];
 
+const MAX_INPUT_BYTES = 5 * 1024 * 1024;
+
+function assertInputSize(text, label = 'input') {
+  const bytes = Buffer.byteLength(text, 'utf8');
+  if (bytes > MAX_INPUT_BYTES) throw new RangeError(`${label} exceeds the ${MAX_INPUT_BYTES / (1024 * 1024)} MiB limit`);
+}
+
 // Word-boundary matchers so "usually" inside "unusually" (or "might" inside
 // "mighty", "often" inside "soften") doesn't register as a hedge.
 const HEDGE_RES = HEDGES.map((h) => new RegExp(`\\b${h.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`));
@@ -182,6 +189,7 @@ function detectClicheOpeners(sentences) {
 
 // ─── Main analysis ──────────────────────────────────────────────────────────
 function analyze(rawText) {
+  assertInputSize(String(rawText));
   // Normalize typographic quotes once, before any detector runs, so curly-quote
   // prose (and stripHtml's decoded &rsquo;) matches the same rules as ASCII text.
   const text = normalizeQuotes(rawText);

--- a/integrations/vscode/detector.js
+++ b/integrations/vscode/detector.js
@@ -45,8 +45,15 @@ const HEDGES = [
 
 const MAX_INPUT_BYTES = 5 * 1024 * 1024;
 
+function utf8ByteLength(text) {
+  if (typeof TextEncoder !== 'undefined') return new TextEncoder().encode(text).length;
+  let bytes = 0;
+  for (const cp of text) bytes += cp.codePointAt(0) <= 0x7f ? 1 : cp.codePointAt(0) <= 0x7ff ? 2 : cp.codePointAt(0) <= 0xffff ? 3 : 4;
+  return bytes;
+}
+
 function assertInputSize(text, label = 'input') {
-  const bytes = Buffer.byteLength(text, 'utf8');
+  const bytes = utf8ByteLength(text);
   if (bytes > MAX_INPUT_BYTES) throw new RangeError(`${label} exceeds the ${MAX_INPUT_BYTES / (1024 * 1024)} MiB limit`);
 }
 

--- a/skills/cadence/scripts/deslop.mjs
+++ b/skills/cadence/scripts/deslop.mjs
@@ -23,6 +23,13 @@ import { relative, join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { extractPdf, extractDocx, extractEpub, fetchUrl, looksReadable } from './extract-text.mjs';
 
+export const MAX_INPUT_BYTES = 5 * 1024 * 1024;
+
+function assertInputSize(text, label = 'input') {
+  const bytes = Buffer.byteLength(text, 'utf8');
+  if (bytes > MAX_INPUT_BYTES) throw new RangeError(`${label} exceeds the ${MAX_INPUT_BYTES / (1024 * 1024)} MiB limit`);
+}
+
 // ─── Lexical rules ──────────────────────────────────────────────────────────
 // Phrases that almost never survive a human editor. Each hit is one finding.
 const BANNED_PHRASES = [
@@ -205,6 +212,7 @@ function detectClicheOpeners(sentences) {
 
 // ─── Main analysis ──────────────────────────────────────────────────────────
 export function analyze(rawText) {
+  assertInputSize(String(rawText));
   // Normalize typographic quotes once, before any detector runs, so curly-quote
   // prose (and stripHtml's decoded &rsquo;) matches the same rules as ASCII text.
   const text = normalizeQuotes(rawText);
@@ -600,7 +608,10 @@ function isMain() {
 
 async function readStdin() {
   const chunks = [];
+  let bytes = 0;
   for await (const c of process.stdin) chunks.push(c);
+  for (const c of chunks) bytes += c.length;
+  if (bytes > MAX_INPUT_BYTES) throw new RangeError(`stdin exceeds the ${MAX_INPUT_BYTES / (1024 * 1024)} MiB limit`);
   return Buffer.concat(chunks).toString('utf8');
 }
 
@@ -631,7 +642,8 @@ if (isMain()) {
 
   let text;
   if (!file) {
-    text = await readStdin();
+    try { text = await readStdin(); }
+    catch (e) { process.stderr.write(`${e.message}\n`); process.exit(2); }
     if (args.includes('--html')) text = stripHtml(text);
     else if (args.includes('--prose-only')) text = stripMarkdown(text);
   } else if (/^https?:\/\//i.test(file)) {
@@ -640,6 +652,10 @@ if (isMain()) {
   } else {
     const lower = file.toLowerCase();
     if (/\.(pdf|docx|epub)$/.test(lower)) {
+      if (statSync(file).size > MAX_INPUT_BYTES) {
+        process.stderr.write(`${file} exceeds the ${MAX_INPUT_BYTES / (1024 * 1024)} MiB limit\n`);
+        process.exit(2);
+      }
       const buf = readFileSync(file);
       try {
         text = lower.endsWith('.pdf') ? extractPdf(buf) : lower.endsWith('.epub') ? extractEpub(buf) : extractDocx(buf);
@@ -649,6 +665,10 @@ if (isMain()) {
         process.exit(3);
       }
     } else {
+      if (statSync(file).size > MAX_INPUT_BYTES) {
+        process.stderr.write(`${file} exceeds the ${MAX_INPUT_BYTES / (1024 * 1024)} MiB limit\n`);
+        process.exit(2);
+      }
       text = readFileSync(file, 'utf8');
       if (args.includes('--html') || /\.html?$/i.test(lower)) text = stripHtml(text);
       else if (args.includes('--prose-only')) text = stripMarkdown(text);

--- a/skills/cadence/scripts/deslop.mjs
+++ b/skills/cadence/scripts/deslop.mjs
@@ -68,8 +68,15 @@ const HEDGES = [
 
 export const MAX_INPUT_BYTES = 5 * 1024 * 1024;
 
+function utf8ByteLength(text) {
+  if (typeof TextEncoder !== 'undefined') return new TextEncoder().encode(text).length;
+  let bytes = 0;
+  for (const cp of text) bytes += cp.codePointAt(0) <= 0x7f ? 1 : cp.codePointAt(0) <= 0x7ff ? 2 : cp.codePointAt(0) <= 0xffff ? 3 : 4;
+  return bytes;
+}
+
 function assertInputSize(text, label = 'input') {
-  const bytes = Buffer.byteLength(text, 'utf8');
+  const bytes = utf8ByteLength(text);
   if (bytes > MAX_INPUT_BYTES) throw new RangeError(`${label} exceeds the ${MAX_INPUT_BYTES / (1024 * 1024)} MiB limit`);
 }
 

--- a/skills/cadence/scripts/deslop.mjs
+++ b/skills/cadence/scripts/deslop.mjs
@@ -23,13 +23,6 @@ import { relative, join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { extractPdf, extractDocx, extractEpub, fetchUrl, looksReadable } from './extract-text.mjs';
 
-export const MAX_INPUT_BYTES = 5 * 1024 * 1024;
-
-function assertInputSize(text, label = 'input') {
-  const bytes = Buffer.byteLength(text, 'utf8');
-  if (bytes > MAX_INPUT_BYTES) throw new RangeError(`${label} exceeds the ${MAX_INPUT_BYTES / (1024 * 1024)} MiB limit`);
-}
-
 // ─── Lexical rules ──────────────────────────────────────────────────────────
 // Phrases that almost never survive a human editor. Each hit is one finding.
 const BANNED_PHRASES = [
@@ -72,6 +65,13 @@ const HEDGES = [
   'seemingly', 'kind of', 'sort of', 'in some ways', 'to some extent',
   'it could be argued', 'one could say',
 ];
+
+export const MAX_INPUT_BYTES = 5 * 1024 * 1024;
+
+function assertInputSize(text, label = 'input') {
+  const bytes = Buffer.byteLength(text, 'utf8');
+  if (bytes > MAX_INPUT_BYTES) throw new RangeError(`${label} exceeds the ${MAX_INPUT_BYTES / (1024 * 1024)} MiB limit`);
+}
 
 // Word-boundary matchers so "usually" inside "unusually" (or "might" inside
 // "mighty", "often" inside "soften") doesn't register as a hedge.

--- a/tests/deslop.test.mjs
+++ b/tests/deslop.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { analyze, splitSentences, words, stripMarkdown, stripHtml, scanDir, applyFixes, addedProseByFile, analyzeParagraphs } from '../skills/cadence/scripts/deslop.mjs';
+import { analyze, splitSentences, words, stripMarkdown, stripHtml, scanDir, applyFixes, addedProseByFile, analyzeParagraphs, MAX_INPUT_BYTES } from '../skills/cadence/scripts/deslop.mjs';
 
 // Representative slop: banned phrases, hollow confidence, uniform rhythm,
 // a negation pivot, a triad, and a cliché opener — all the tells at once.
@@ -138,6 +138,10 @@ test('empty input is safe', () => {
   const r = analyze('');
   assert.equal(r.score, 0);
   assert.equal(r.metrics.sentences, 0);
+});
+
+test('analyze rejects input over the documented limit', () => {
+  assert.throws(() => analyze('x'.repeat(MAX_INPUT_BYTES + 1)), /exceeds/);
 });
 
 test('words() and splitSentences() are exported and pure', () => {

--- a/tests/extension.test.mjs
+++ b/tests/extension.test.mjs
@@ -27,3 +27,14 @@ test('the browser detector matches deslop.mjs exactly (run `npm run build:extens
     assert.equal(win.cadenceAnalyze(s).grade, analyze(s).grade);
   }
 });
+
+test('the browser detector enforces input limits without Node Buffer', () => {
+  const saved = globalThis.Buffer;
+  try {
+    globalThis.Buffer = undefined;
+    assert.doesNotThrow(() => win.cadenceAnalyze('A normal browser input.'));
+    assert.throws(() => win.cadenceAnalyze('x'.repeat(5 * 1024 * 1024 + 1)), /exceeds/);
+  } finally {
+    globalThis.Buffer = saved;
+  }
+});


### PR DESCRIPTION
## Summary

- Define a 5 MiB input limit for analyzer text and CLI file/document paths.
- Reject oversized stdin and files with a clear message and exit code 2.
- Document the limit and add regression coverage.

## Verification

- `npm test` passes.
- `npm run check:docs` passes.