### PR TITLE
Fix seed voice count documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ sentence-usage traits into that voice profile. Build it with
 | [benchmark/README.md](benchmark/README.md) | The accuracy benchmark: labeled corpus, published precision and recall, and the CI gate |
 | [benchmark/EVALUATION.md](benchmark/EVALUATION.md) | Evaluation protocol for regression fixtures, provenance, leakage, and held-out data |
 | [lora/README.md](lora/README.md) | LoRA-Cadence: train a slop-humanizing QLoRA graded by the detector, plus the Kaggle notebook |
+| [lora/DATASET_FEASIBILITY.md](lora/DATASET_FEASIBILITY.md) | License, provenance, leakage, and evaluation gate for external LoRA datasets |
 | [PHILOSOPHY.md](PHILOSOPHY.md) | The thinking behind it — *The Age of Taste* |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | How the project is built and how to add a rule, voice, or command |
 | [CHANGELOG.md](CHANGELOG.md) | Version history |

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "test": "node --test tests/deslop.test.mjs tests/extract-text.test.mjs tests/extension.test.mjs tests/vscode.test.mjs tests/benchmark.test.mjs",
+    "test": "node --test tests/deslop.test.mjs tests/extract-text.test.mjs tests/extension.test.mjs tests/vscode.test.mjs tests/benchmark.test.mjs tests/voices.test.mjs",
     "deslop": "node skills/cadence/scripts/deslop.mjs",
     "bench": "node benchmark/bench.mjs",
     "bench:check": "node benchmark/bench.mjs --check",

--- a/skills/cadence/SKILL.md
+++ b/skills/cadence/SKILL.md
@@ -126,7 +126,7 @@ them to the right command — answer their situation, not a keyword.
 | See the voices you can pick from | `voices` | `/cadence voices` |
 
 Not sure? Tell me what you have — a draft to fix, an idea to write, or a writer
-you want to sound like — and I'll route it. Nine voices ship today; run
+you want to sound like — and I'll route it. Ten voices ship today; run
 `/cadence voices` to read them.
 ```
 

--- a/tests/voices.test.mjs
+++ b/tests/voices.test.mjs
@@ -1,0 +1,26 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+
+const root = new URL('../', import.meta.url);
+const seedNames = readdirSync(new URL('voices/', root))
+  .filter((name) => name.endsWith('.md'))
+  .map((name) => name.slice(0, -3))
+  .sort();
+
+test('SKILL.md lists every shipped seed voice exactly once', () => {
+  const skill = readFileSync(new URL('skills/cadence/SKILL.md', root), 'utf8');
+  const marker = skill.match(/\*\*Shipped seeds\*\*[\s\S]*?(?=\n- \*\*The user's own voices\*\*)/);
+  assert.ok(marker, 'canonical shipped-seeds section is missing');
+  const documented = [...marker[0].matchAll(/`([^`]+)`/g)]
+    .map((match) => match[1])
+    .filter((name) => !name.includes('/') && name !== 'voices/*.md');
+  assert.deepEqual([...new Set(documented)].sort(), seedNames);
+  assert.equal(documented.length, seedNames.length);
+});
+
+test('current picker copy uses the actual shipped seed count', () => {
+  const skill = readFileSync(new URL('skills/cadence/SKILL.md', root), 'utf8');
+  assert.match(skill, /ten seeds ship today/);
+  assert.match(skill, /Ten voices ship today/);
+});


### PR DESCRIPTION
## Summary

Closes #7.

- Correct the current picker copy from nine voices to ten.
- Add a regression test that treats the shipped `voices/*.md` files as canonical and verifies the documented seed list and count.

The historical five-voice changelog entry remains unchanged because it describes an older release.

## Verification

- `npm test` passes.
- `npm run check:docs` passes.
- `git diff --check` passes.