### PR TITLE
Make the Kaggle LoRA notebook easier to run

### DIFF
--- a/lora/README.md
+++ b/lora/README.md
@@ -60,13 +60,32 @@ still hand-read a sample.
 [train_qwen_kaggle.py](train_qwen_kaggle.py), percent-format) runs the whole flow:
 rank-16 QLoRA on Qwen2.5-3B, Phase-1 grade-A filter, train, generate each arm's
 outputs, and grade with the real detector. Cell 3 proves the `deslop.mjs` wiring on
-sample data before any GPU time. Leave `DRY_RUN = True` to execute end-to-end on the
-sample data with no training; set it to False once your dataset is in place.
+sample data before any GPU time. The notebook uses three modes: `dry` (default,
+sample data and no GPU), `smoke` (two GPU training steps), and `train` (the full
+configured run).
 
-Turn on GPU and Internet in the Kaggle settings, and cache the base model as a
-Kaggle Dataset after the first run. The grading and filter cells are verified; the
-Unsloth/trl training cells follow the current quickstart and may need small tweaks as
-those libraries drift.
+### Run it on Kaggle
+
+1. Open or upload `train_qwen_kaggle.ipynb` in Kaggle.
+2. Attach a Kaggle Dataset containing `raw_pairs.jsonl` with `instruction`, `input`,
+   and `output` fields. Set `DATASET_PATH` only when automatic discovery cannot find
+   it.
+3. Start with `RUN_MODE = "dry"`. Select a T4/P100 GPU only for `smoke` or `train`.
+   Enable Internet when installing Unsloth or downloading the base model.
+4. Run `smoke` before a full job. The notebook validates Node, CUDA, the dataset,
+   and the grade-A filter before spending training time.
+5. Download `cadence-output.zip` from the notebook Output panel. It contains the
+   filtered pairs, held-out inputs, generated arms, detector results, writeup, and
+   run configuration; it never includes the base model.
+
+The Python file is the canonical source. Regenerate the notebook after editing it:
+
+```bash
+python3 scripts/build-kaggle-notebook.py
+```
+
+The dry path is the reproducible wiring check. Full GPU training remains dependent
+on the Kaggle image's current Unsloth, TRL, CUDA, and PyTorch versions.
 
 ## How the Kaggle notebook uses this
 

--- a/lora/train_qwen_kaggle.ipynb
+++ b/lora/train_qwen_kaggle.ipynb
@@ -15,41 +15,64 @@
     "the base model as a Kaggle Dataset after the first run to protect your quota.\n",
     "\n",
     "The notebook proves the grading wiring on sample data FIRST (cell 3), before any\n",
-    "GPU time. Leave `DRY_RUN = True` to execute end-to-end on the repo's sample data;\n",
-    "set it to False once your own dataset is in place."
+    "GPU time. Start with `RUN_MODE = \"dry\"` to execute end-to-end on the repo's sample data;\n",
+    "set it to False once your own dataset is in place.\n",
+    "\n"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# ---- config ----\n",
-    "DRY_RUN = True   # True: run the whole flow on repo sample data, no training. False: real run.\n",
+    "RUN_MODE = \"dry\"  # one of: dry (no GPU), smoke (2 GPU steps), train (full run)\n",
+    "DATASET_PATH = None  # e.g. \"/kaggle/input/my-cadence-pairs\"\n",
+    "OUTPUT_DIR = \"/kaggle/working/cadence-output\"\n",
+    "SEED = 42\n",
     "\n",
     "BASE_MODEL = \"unsloth/Qwen2.5-3B-Instruct-bnb-4bit\"\n",
     "LORA_R, LORA_ALPHA, LORA_DROPOUT = 16, 32, 0.05\n",
     "MAX_SEQ = 2048\n",
     "GRADE_A_MAX = 10          # target quality floor for training pairs (Cadence grade A = score <= 10)\n",
-    "MAX_TRAIN_STEPS = 200     # keep short on a small set to avoid overfitting\n",
+    "MAX_TRAIN_STEPS = 200 if RUN_MODE == \"train\" else 2\n",
     "\n",
     "# The one instruction both training and inference use.\n",
     "HUMANIZE = (\"Rewrite the text so it reads like a person wrote it: vary sentence length, \"\n",
     "            \"cut hollow-confidence words and cliches, no em-dashes. Keep the meaning and every \"\n",
-    "            \"fact intact. Output only the rewrite.\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+    "            \"fact intact. Output only the rewrite.\")\n",
+    "\n"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# ---- cell 3: wire and PROVE the real detector before any GPU time ----\n",
-    "import os, subprocess, json, shutil\n",
+    "import os, subprocess, json, shutil, random, platform, pathlib, zipfile\n",
+    "\n",
+    "assert RUN_MODE in {\"dry\", \"smoke\", \"train\"}, \"RUN_MODE must be dry, smoke, or train\"\n",
+    "random.seed(SEED)\n",
+    "os.makedirs(OUTPUT_DIR, exist_ok=True)\n",
+    "\n",
+    "def fail(message):\n",
+    "    raise RuntimeError(f\"Kaggle setup: {message}\")\n",
+    "\n",
+    "def preflight():\n",
+    "    print(f\"Python {platform.python_version()} \u00b7 mode={RUN_MODE} \u00b7 seed={SEED}\")\n",
+    "    if RUN_MODE in {\"smoke\", \"train\"}:\n",
+    "        import torch\n",
+    "        if not torch.cuda.is_available(): fail(\"select a GPU accelerator before smoke/train mode\")\n",
+    "        print(\"GPU:\", torch.cuda.get_device_name(0))\n",
+    "\n",
+    "preflight()\n",
     "\n",
     "# Get the Cadence repo. Prefer it added as a Kaggle Dataset; else clone it.\n",
     "REPO = None\n",
-    "for cand in [\"/kaggle/input/cadence\", \"/kaggle/input/Cadence\", \"/kaggle/working/Cadence\"]:\n",
+    "for cand in [\"/kaggle/input/cadence\", \"/kaggle/input/Cadence\", \"/kaggle/working/Cadence\", os.getcwd()]:\n",
     "    if os.path.exists(os.path.join(cand, \"lora\", \"eval.mjs\")):\n",
     "        REPO = cand; break\n",
     "if REPO is None:\n",
@@ -88,10 +111,9 @@
     "\n",
     "# SMOKE TEST: grade the repo's sample arms. This must work before we train anything.\n",
     "grade_table({\"base\": f\"{REPO}/lora/sample/base.jsonl\",\n",
-    "             \"recast\": f\"{REPO}/lora/sample/recast.jsonl\"})"
-   ],
-   "outputs": [],
-   "execution_count": null
+    "             \"recast\": f\"{REPO}/lora/sample/recast.jsonl\"})\n",
+    "\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -102,36 +124,48 @@
     "Give it ONE file: `raw_pairs.jsonl` of `{\"instruction\",\"input\",\"output\"}` (each\n",
     "`output` a prompt-`recast` humanization made with your API key, before this notebook;\n",
     "add an optional `\"source\"` field per row for a leak-free split). The notebook then\n",
-    "filters to grade-A targets and carves out the held-out eval set itself. In DRY_RUN it\n",
-    "synthesizes a tiny raw file from the sample data so the whole flow runs."
+    "filters to grade-A targets and carves out the held-out eval set itself. In dry mode it\n",
+    "synthesizes a tiny raw file from the sample data so the whole flow runs.\n",
+    "\n"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "import json, hashlib\n",
     "\n",
-    "TRAIN_PAIRS = \"/kaggle/working/train_pairs.jsonl\"     # verified + train-split\n",
-    "HELDOUT = \"/kaggle/working/heldout_slop.jsonl\"        # auto-carved, model never sees these\n",
+    "TRAIN_PAIRS = os.path.join(OUTPUT_DIR, \"train_pairs.jsonl\")     # verified + train-split\n",
+    "HELDOUT = os.path.join(OUTPUT_DIR, \"heldout_slop.jsonl\")        # auto-carved, model never sees these\n",
     "HOLDOUT_FRAC = 0.15\n",
     "\n",
     "def read_jsonl(p): return [json.loads(l) for l in open(p) if l.strip()]\n",
     "def write_jsonl(p, rows): open(p, \"w\").write(\"\\n\".join(json.dumps(r) for r in rows) + \"\\n\")\n",
     "\n",
-    "if DRY_RUN:\n",
+    "if RUN_MODE == \"dry\":\n",
     "    base = read_jsonl(f\"{REPO}/lora/sample/base.jsonl\")\n",
     "    recast = read_jsonl(f\"{REPO}/lora/sample/recast.jsonl\")\n",
-    "    write_jsonl(\"/kaggle/working/raw_pairs.jsonl\",\n",
+    "    write_jsonl(os.path.join(OUTPUT_DIR, \"raw_pairs.jsonl\"),\n",
     "                [{\"id\": b[\"id\"], \"source\": \"sample\", \"instruction\": HUMANIZE,\n",
     "                  \"input\": b[\"text\"], \"output\": r[\"text\"]} for b, r in zip(base, recast)])\n",
-    "    RAW = \"/kaggle/working/raw_pairs.jsonl\"\n",
+    "    RAW = os.path.join(OUTPUT_DIR, \"raw_pairs.jsonl\")\n",
     "else:\n",
-    "    RAW = \"/kaggle/input/YOUR_DATASET/raw_pairs.jsonl\"   # <-- point at your data\n",
+    "    candidates = list(pathlib.Path(\"/kaggle/input\").glob(\"**/raw_pairs.jsonl\")) if os.path.isdir(\"/kaggle/input\") else []\n",
+    "    if DATASET_PATH:\n",
+    "        RAW = os.path.join(DATASET_PATH, \"raw_pairs.jsonl\")\n",
+    "    elif len(candidates) == 1:\n",
+    "        RAW = str(candidates[0])\n",
+    "    else:\n",
+    "        fail(\"attach one dataset containing raw_pairs.jsonl or set DATASET_PATH\")\n",
     "\n",
     "# The key gate: keep only pairs whose target the detector verifies as grade-A.\n",
-    "filter_pairs(RAW, \"/kaggle/working/verified.jsonl\", max_score=GRADE_A_MAX)\n",
-    "verified = read_jsonl(\"/kaggle/working/verified.jsonl\")\n",
+    "verified_path = os.path.join(OUTPUT_DIR, \"verified.jsonl\")\n",
+    "filter_pairs(RAW, verified_path, max_score=GRADE_A_MAX)\n",
+    "verified = read_jsonl(verified_path)\n",
+    "if not verified:\n",
+    "    fail(\"no pairs survived the Cadence grade-A filter\")\n",
     "\n",
     "# Auto held-out split: group by source (so a whole source is held out, not leaked\n",
     "# across the split), deterministic, no manual second file.\n",
@@ -142,25 +176,27 @@
     "write_jsonl(TRAIN_PAIRS, train)\n",
     "write_jsonl(HELDOUT, [{\"id\": r.get(\"id\", f\"h{i}\"), \"input\": r[\"input\"]} for i, r in enumerate(held)])\n",
     "pairs = train\n",
-    "print(f\"{len(verified)} verified -> {len(train)} train / {len(held)} held-out (split by source)\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+    "print(f\"{len(verified)} verified -> {len(train)} train / {len(held)} held-out (split by source)\")\n",
+    "\n"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Phase 2 - train the QLoRA\n",
-    "Skipped entirely under DRY_RUN. Unsloth's API drifts; if an import fails, check the\n",
-    "current Unsloth Kaggle quickstart and adjust the two cells below."
+    "Skipped entirely under dry mode. Unsloth's API drifts; if an import fails, check the\n",
+    "current Unsloth Kaggle quickstart and adjust the two cells below.\n",
+    "\n"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "if not DRY_RUN:\n",
+    "if RUN_MODE in {\"smoke\", \"train\"}:\n",
     "    import subprocess as _sp\n",
     "    _sp.run([\"pip\", \"install\", \"-q\", \"unsloth\"], check=True)\n",
     "\n",
@@ -174,16 +210,17 @@
     "        model, r=LORA_R, lora_alpha=LORA_ALPHA, lora_dropout=LORA_DROPOUT,\n",
     "        target_modules=[\"q_proj\", \"k_proj\", \"v_proj\", \"o_proj\",\n",
     "                        \"gate_proj\", \"up_proj\", \"down_proj\"],\n",
-    "        use_gradient_checkpointing=\"unsloth\", random_state=42)"
-   ],
-   "outputs": [],
-   "execution_count": null
+    "        use_gradient_checkpointing=\"unsloth\", random_state=42)\n",
+    "\n"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "if not DRY_RUN:\n",
+    "if RUN_MODE in {\"smoke\", \"train\"}:\n",
     "    from datasets import Dataset\n",
     "    from trl import SFTTrainer\n",
     "    from transformers import TrainingArguments\n",
@@ -204,25 +241,27 @@
     "            fp16=not bf16, bf16=bf16, logging_steps=10, optim=\"adamw_8bit\",\n",
     "            weight_decay=0.01, lr_scheduler_type=\"linear\", seed=42, output_dir=\"outputs\"))\n",
     "    trainer.train()\n",
-    "    model.save_pretrained(\"/kaggle/working/cadence_lora\")   # the tiny adapter\n",
-    "    tokenizer.save_pretrained(\"/kaggle/working/cadence_lora\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+    "    model.save_pretrained(os.path.join(OUTPUT_DIR, \"cadence_lora\"))   # the tiny adapter\n",
+    "    tokenizer.save_pretrained(os.path.join(OUTPUT_DIR, \"cadence_lora\"))\n",
+    "\n"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Phase 3 - generate each arm's outputs, then grade with the real detector"
+    "## Phase 3 - generate each arm's outputs, then grade with the real detector\n",
+    "\n"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "def make_generate():\n",
-    "    if DRY_RUN:\n",
+    "    if RUN_MODE == \"dry\":\n",
     "        return None\n",
     "    from unsloth import FastLanguageModel\n",
     "    FastLanguageModel.for_inference(model)\n",
@@ -235,9 +274,9 @@
     "    return gen\n",
     "\n",
     "heldout = read_jsonl(HELDOUT)\n",
-    "OUT_BASE, OUT_LORA = \"/kaggle/working/out_base.jsonl\", \"/kaggle/working/out_lora.jsonl\"\n",
+    "OUT_BASE, OUT_LORA = os.path.join(OUTPUT_DIR, \"out_base.jsonl\"), os.path.join(OUTPUT_DIR, \"out_lora.jsonl\")\n",
     "\n",
-    "if DRY_RUN:\n",
+    "if RUN_MODE == \"dry\":\n",
     "    # No model: build both arms from the held-out ids using the sample texts, so the\n",
     "    # arms line up with the split and the table renders.\n",
     "    held_ids = [r[\"id\"] for r in heldout]\n",
@@ -254,28 +293,30 @@
     "# Optional Arm C (the ceiling): outputs from the prompt-based recast on a frontier\n",
     "# model, generated with your API key elsewhere, dropped in as out_prompt.jsonl.\n",
     "arms = {\"base\": OUT_BASE, \"lora\": OUT_LORA}\n",
-    "if os.path.exists(\"/kaggle/working/out_prompt.jsonl\"):\n",
-    "    arms[\"prompt\"] = \"/kaggle/working/out_prompt.jsonl\""
-   ],
-   "outputs": [],
-   "execution_count": null
+    "if os.path.exists(os.path.join(OUTPUT_DIR, \"out_prompt.jsonl\")):\n",
+    "    arms[\"prompt\"] = os.path.join(OUTPUT_DIR, \"out_prompt.jsonl\")\n",
+    "\n"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# ---- the result: score + rhythm CV + per-tell, from the real detector ----\n",
     "grade_table(arms)\n",
     "results = grade_json(arms)\n",
-    "json.dump(results, open(\"/kaggle/working/results.json\", \"w\"), indent=2)\n",
-    "print(\"\\nsaved results.json\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+    "json.dump(results, open(os.path.join(OUTPUT_DIR, \"results.json\"), \"w\"), indent=2)\n",
+    "print(\"\\nsaved results.json\")\n",
+    "\n"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# ---- Phase 4: writeup + the two honesty gates, computed not narrated ----\n",
     "R = {a[\"name\"]: a for a in results[\"arms\"]}\n",
@@ -306,7 +347,7 @@
     "                    \"flagged phrases without learning to vary sentence length. Report this, not just the score.\")\n",
     "\n",
     "writeup = \"\\n\\n\".join(para) or \"Need both a base and a lora arm to write up.\"\n",
-    "open(\"/kaggle/working/writeup.md\", \"w\").write(writeup + \"\\n\")\n",
+    "open(os.path.join(OUTPUT_DIR, \"writeup.md\"), \"w\").write(writeup + \"\\n\")\n",
     "print(writeup)\n",
     "\n",
     "# Gate 2 - tee up the hand meaning-check the detector cannot do.\n",
@@ -316,11 +357,13 @@
     "    print(f\"\\n[{r['id']}] IN : {ho.get(r['id'], '')[:200]}\")\n",
     "    print(f\"[{r['id']}] OUT: {r['text'][:200]}\")\n",
     "\n",
-    "print(\"\\nArtifacts to commit (NOT the base model): \"\n",
-    "      \"cadence_lora/, train_pairs.jsonl, heldout_slop.jsonl, results.json, writeup.md\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+    "config = {\"run_mode\": RUN_MODE, \"base_model\": BASE_MODEL, \"seed\": SEED, \"grade_a_max\": GRADE_A_MAX, \"max_train_steps\": MAX_TRAIN_STEPS}\n",
+    "json.dump(config, open(os.path.join(OUTPUT_DIR, \"run-config.json\"), \"w\"), indent=2)\n",
+    "with zipfile.ZipFile(os.path.join(OUTPUT_DIR, \"cadence-output.zip\"), \"w\", zipfile.ZIP_DEFLATED) as z:\n",
+    "    for p in pathlib.Path(OUTPUT_DIR).rglob(\"*\"):\n",
+    "        if p.name != \"cadence-output.zip\" and p.is_file(): z.write(p, p.relative_to(OUTPUT_DIR))\n",
+    "print(f\"\\nArtifacts are in {OUTPUT_DIR}; download cadence-output.zip from the Kaggle Output tab.\")\n"
+   ]
   }
  ],
  "metadata": {

--- a/lora/train_qwen_kaggle.py
+++ b/lora/train_qwen_kaggle.py
@@ -10,18 +10,21 @@
 # the base model as a Kaggle Dataset after the first run to protect your quota.
 #
 # The notebook proves the grading wiring on sample data FIRST (cell 3), before any
-# GPU time. Leave `DRY_RUN = True` to execute end-to-end on the repo's sample data;
+# GPU time. Start with `RUN_MODE = "dry"` to execute end-to-end on the repo's sample data;
 # set it to False once your own dataset is in place.
 
 # %%
 # ---- config ----
-DRY_RUN = True   # True: run the whole flow on repo sample data, no training. False: real run.
+RUN_MODE = "dry"  # one of: dry (no GPU), smoke (2 GPU steps), train (full run)
+DATASET_PATH = None  # e.g. "/kaggle/input/my-cadence-pairs"
+OUTPUT_DIR = "/kaggle/working/cadence-output"
+SEED = 42
 
 BASE_MODEL = "unsloth/Qwen2.5-3B-Instruct-bnb-4bit"
 LORA_R, LORA_ALPHA, LORA_DROPOUT = 16, 32, 0.05
 MAX_SEQ = 2048
 GRADE_A_MAX = 10          # target quality floor for training pairs (Cadence grade A = score <= 10)
-MAX_TRAIN_STEPS = 200     # keep short on a small set to avoid overfitting
+MAX_TRAIN_STEPS = 200 if RUN_MODE == "train" else 2
 
 # The one instruction both training and inference use.
 HUMANIZE = ("Rewrite the text so it reads like a person wrote it: vary sentence length, "
@@ -30,11 +33,27 @@ HUMANIZE = ("Rewrite the text so it reads like a person wrote it: vary sentence 
 
 # %%
 # ---- cell 3: wire and PROVE the real detector before any GPU time ----
-import os, subprocess, json, shutil
+import os, subprocess, json, shutil, random, platform, pathlib, zipfile
+
+assert RUN_MODE in {"dry", "smoke", "train"}, "RUN_MODE must be dry, smoke, or train"
+random.seed(SEED)
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+def fail(message):
+    raise RuntimeError(f"Kaggle setup: {message}")
+
+def preflight():
+    print(f"Python {platform.python_version()} · mode={RUN_MODE} · seed={SEED}")
+    if RUN_MODE in {"smoke", "train"}:
+        import torch
+        if not torch.cuda.is_available(): fail("select a GPU accelerator before smoke/train mode")
+        print("GPU:", torch.cuda.get_device_name(0))
+
+preflight()
 
 # Get the Cadence repo. Prefer it added as a Kaggle Dataset; else clone it.
 REPO = None
-for cand in ["/kaggle/input/cadence", "/kaggle/input/Cadence", "/kaggle/working/Cadence"]:
+for cand in ["/kaggle/input/cadence", "/kaggle/input/Cadence", "/kaggle/working/Cadence", os.getcwd()]:
     if os.path.exists(os.path.join(cand, "lora", "eval.mjs")):
         REPO = cand; break
 if REPO is None:
@@ -81,32 +100,41 @@ grade_table({"base": f"{REPO}/lora/sample/base.jsonl",
 # Give it ONE file: `raw_pairs.jsonl` of `{"instruction","input","output"}` (each
 # `output` a prompt-`recast` humanization made with your API key, before this notebook;
 # add an optional `"source"` field per row for a leak-free split). The notebook then
-# filters to grade-A targets and carves out the held-out eval set itself. In DRY_RUN it
+# filters to grade-A targets and carves out the held-out eval set itself. In dry mode it
 # synthesizes a tiny raw file from the sample data so the whole flow runs.
 
 # %%
 import json, hashlib
 
-TRAIN_PAIRS = "/kaggle/working/train_pairs.jsonl"     # verified + train-split
-HELDOUT = "/kaggle/working/heldout_slop.jsonl"        # auto-carved, model never sees these
+TRAIN_PAIRS = os.path.join(OUTPUT_DIR, "train_pairs.jsonl")     # verified + train-split
+HELDOUT = os.path.join(OUTPUT_DIR, "heldout_slop.jsonl")        # auto-carved, model never sees these
 HOLDOUT_FRAC = 0.15
 
 def read_jsonl(p): return [json.loads(l) for l in open(p) if l.strip()]
 def write_jsonl(p, rows): open(p, "w").write("\n".join(json.dumps(r) for r in rows) + "\n")
 
-if DRY_RUN:
+if RUN_MODE == "dry":
     base = read_jsonl(f"{REPO}/lora/sample/base.jsonl")
     recast = read_jsonl(f"{REPO}/lora/sample/recast.jsonl")
-    write_jsonl("/kaggle/working/raw_pairs.jsonl",
+    write_jsonl(os.path.join(OUTPUT_DIR, "raw_pairs.jsonl"),
                 [{"id": b["id"], "source": "sample", "instruction": HUMANIZE,
                   "input": b["text"], "output": r["text"]} for b, r in zip(base, recast)])
-    RAW = "/kaggle/working/raw_pairs.jsonl"
+    RAW = os.path.join(OUTPUT_DIR, "raw_pairs.jsonl")
 else:
-    RAW = "/kaggle/input/YOUR_DATASET/raw_pairs.jsonl"   # <-- point at your data
+    candidates = list(pathlib.Path("/kaggle/input").glob("**/raw_pairs.jsonl")) if os.path.isdir("/kaggle/input") else []
+    if DATASET_PATH:
+        RAW = os.path.join(DATASET_PATH, "raw_pairs.jsonl")
+    elif len(candidates) == 1:
+        RAW = str(candidates[0])
+    else:
+        fail("attach one dataset containing raw_pairs.jsonl or set DATASET_PATH")
 
 # The key gate: keep only pairs whose target the detector verifies as grade-A.
-filter_pairs(RAW, "/kaggle/working/verified.jsonl", max_score=GRADE_A_MAX)
-verified = read_jsonl("/kaggle/working/verified.jsonl")
+verified_path = os.path.join(OUTPUT_DIR, "verified.jsonl")
+filter_pairs(RAW, verified_path, max_score=GRADE_A_MAX)
+verified = read_jsonl(verified_path)
+if not verified:
+    fail("no pairs survived the Cadence grade-A filter")
 
 # Auto held-out split: group by source (so a whole source is held out, not leaked
 # across the split), deterministic, no manual second file.
@@ -121,11 +149,11 @@ print(f"{len(verified)} verified -> {len(train)} train / {len(held)} held-out (s
 
 # %% [markdown]
 # ## Phase 2 - train the QLoRA
-# Skipped entirely under DRY_RUN. Unsloth's API drifts; if an import fails, check the
+# Skipped entirely under dry mode. Unsloth's API drifts; if an import fails, check the
 # current Unsloth Kaggle quickstart and adjust the two cells below.
 
 # %%
-if not DRY_RUN:
+if RUN_MODE in {"smoke", "train"}:
     import subprocess as _sp
     _sp.run(["pip", "install", "-q", "unsloth"], check=True)
 
@@ -142,7 +170,7 @@ if not DRY_RUN:
         use_gradient_checkpointing="unsloth", random_state=42)
 
 # %%
-if not DRY_RUN:
+if RUN_MODE in {"smoke", "train"}:
     from datasets import Dataset
     from trl import SFTTrainer
     from transformers import TrainingArguments
@@ -163,15 +191,15 @@ if not DRY_RUN:
             fp16=not bf16, bf16=bf16, logging_steps=10, optim="adamw_8bit",
             weight_decay=0.01, lr_scheduler_type="linear", seed=42, output_dir="outputs"))
     trainer.train()
-    model.save_pretrained("/kaggle/working/cadence_lora")   # the tiny adapter
-    tokenizer.save_pretrained("/kaggle/working/cadence_lora")
+    model.save_pretrained(os.path.join(OUTPUT_DIR, "cadence_lora"))   # the tiny adapter
+    tokenizer.save_pretrained(os.path.join(OUTPUT_DIR, "cadence_lora"))
 
 # %% [markdown]
 # ## Phase 3 - generate each arm's outputs, then grade with the real detector
 
 # %%
 def make_generate():
-    if DRY_RUN:
+    if RUN_MODE == "dry":
         return None
     from unsloth import FastLanguageModel
     FastLanguageModel.for_inference(model)
@@ -184,9 +212,9 @@ def make_generate():
     return gen
 
 heldout = read_jsonl(HELDOUT)
-OUT_BASE, OUT_LORA = "/kaggle/working/out_base.jsonl", "/kaggle/working/out_lora.jsonl"
+OUT_BASE, OUT_LORA = os.path.join(OUTPUT_DIR, "out_base.jsonl"), os.path.join(OUTPUT_DIR, "out_lora.jsonl")
 
-if DRY_RUN:
+if RUN_MODE == "dry":
     # No model: build both arms from the held-out ids using the sample texts, so the
     # arms line up with the split and the table renders.
     held_ids = [r["id"] for r in heldout]
@@ -203,14 +231,14 @@ else:
 # Optional Arm C (the ceiling): outputs from the prompt-based recast on a frontier
 # model, generated with your API key elsewhere, dropped in as out_prompt.jsonl.
 arms = {"base": OUT_BASE, "lora": OUT_LORA}
-if os.path.exists("/kaggle/working/out_prompt.jsonl"):
-    arms["prompt"] = "/kaggle/working/out_prompt.jsonl"
+if os.path.exists(os.path.join(OUTPUT_DIR, "out_prompt.jsonl")):
+    arms["prompt"] = os.path.join(OUTPUT_DIR, "out_prompt.jsonl")
 
 # %%
 # ---- the result: score + rhythm CV + per-tell, from the real detector ----
 grade_table(arms)
 results = grade_json(arms)
-json.dump(results, open("/kaggle/working/results.json", "w"), indent=2)
+json.dump(results, open(os.path.join(OUTPUT_DIR, "results.json"), "w"), indent=2)
 print("\nsaved results.json")
 
 # %%
@@ -243,7 +271,7 @@ if base and lora:
                     "flagged phrases without learning to vary sentence length. Report this, not just the score.")
 
 writeup = "\n\n".join(para) or "Need both a base and a lora arm to write up."
-open("/kaggle/working/writeup.md", "w").write(writeup + "\n")
+open(os.path.join(OUTPUT_DIR, "writeup.md"), "w").write(writeup + "\n")
 print(writeup)
 
 # Gate 2 - tee up the hand meaning-check the detector cannot do.
@@ -253,5 +281,9 @@ for r in read_jsonl(OUT_LORA)[:10]:
     print(f"\n[{r['id']}] IN : {ho.get(r['id'], '')[:200]}")
     print(f"[{r['id']}] OUT: {r['text'][:200]}")
 
-print("\nArtifacts to commit (NOT the base model): "
-      "cadence_lora/, train_pairs.jsonl, heldout_slop.jsonl, results.json, writeup.md")
+config = {"run_mode": RUN_MODE, "base_model": BASE_MODEL, "seed": SEED, "grade_a_max": GRADE_A_MAX, "max_train_steps": MAX_TRAIN_STEPS}
+json.dump(config, open(os.path.join(OUTPUT_DIR, "run-config.json"), "w"), indent=2)
+with zipfile.ZipFile(os.path.join(OUTPUT_DIR, "cadence-output.zip"), "w", zipfile.ZIP_DEFLATED) as z:
+    for p in pathlib.Path(OUTPUT_DIR).rglob("*"):
+        if p.name != "cadence-output.zip" and p.is_file(): z.write(p, p.relative_to(OUTPUT_DIR))
+print(f"\nArtifacts are in {OUTPUT_DIR}; download cadence-output.zip from the Kaggle Output tab.")

--- a/scripts/build-kaggle-notebook.py
+++ b/scripts/build-kaggle-notebook.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Generate the Kaggle notebook from the canonical percent-format Python file."""
+import json
+from pathlib import Path
+
+source = Path('lora/train_qwen_kaggle.py').read_text().splitlines()
+cells, current, kind = [], [], 'code'
+
+def flush():
+    if not current:
+        return
+    if kind == 'markdown':
+        cells.append({'cell_type': 'markdown', 'metadata': {}, 'source': [f'{line}\n' for line in current]})
+    else:
+        cells.append({'cell_type': 'code', 'execution_count': None, 'metadata': {}, 'outputs': [], 'source': [f'{line}\n' for line in current]})
+    current.clear()
+
+for line in source:
+    if line == '# %% [markdown]':
+        flush(); kind = 'markdown'; continue
+    if line.startswith('# %%'):
+        flush(); kind = 'code'; continue
+    current.append(line[1:].lstrip() if kind == 'markdown' and line.startswith('#') else line)
+flush()
+
+notebook = {
+    'cells': cells,
+    'metadata': {'kernelspec': {'display_name': 'Python 3', 'language': 'python', 'name': 'python3'}, 'language_info': {'name': 'python', 'version': '3.10'}, 'accelerator': 'GPU'},
+    'nbformat': 4,
+    'nbformat_minor': 5,
+}
+Path('lora/train_qwen_kaggle.ipynb').write_text(json.dumps(notebook, indent=1) + '\n')
+print(f'generated lora/train_qwen_kaggle.ipynb ({len(cells)} cells)')


### PR DESCRIPTION
## Summary

Improve the Kaggle training workflow without publishing an unverified Kaggle URL:

- Add `dry`, `smoke`, and `train` run modes, with dry mode remaining the default.
- Add preflight validation for mode and GPU requirements, configurable dataset discovery, and actionable failures when no pairs survive filtering.
- Use a configurable output directory and package results/configuration into `cadence-output.zip`.
- Make the notebook generated from the canonical percent-format Python source.
- Add clear Kaggle setup, dataset schema, accelerator, Internet, and output-download instructions.

## Verification

- Python source and notebook compile/parse successfully.
- Notebook generation is deterministic.
- `npm test` — 43 passing.
- `npm run check:docs` — passing.
- Full GPU/Unsloth training remains unverified locally and is documented as such.