### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Because detector rules affect scores, any release that changes a rule says so he
 
 ## [Unreleased]
 
-## [0.3.0] — prepared, not yet released
+## [0.3.0] — 2026-09-10
 
 ### Added
 
@@ -167,6 +167,6 @@ First public release.
 - The detector is English-only for now (its function-word and phrase lists are
   English).
 
-[0.3.0]: https://github.com/wuisabel-gif/Cadence/compare/v0.2.0...main
+[0.3.0]: https://github.com/wuisabel-gif/Cadence/releases/tag/v0.3.0
 [0.2.0]: https://github.com/wuisabel-gif/Cadence/releases/tag/v0.2.0
 [0.1.0]: https://github.com/wuisabel-gif/Cadence/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ npm run release:check  # tests + docs + benchmark + packaged agent installs
 
 ## Status
 
-v0.3.0 is being prepared; it has not been published. The checkout includes the
+v0.3.0 is released. The npm package and checkout include the
 agent installers and the tested detector. Release notes and remaining manual checks
 are in [docs/releases/v0.3.0.md](docs/releases/v0.3.0.md). GPU training remains an
 experiment, not a verified release feature.

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,7 +1,7 @@
-# Cadence v0.3.0 — release preparation
+# Cadence v0.3.0
 
-Status: prepared in source, **not published**. No release tag or store submission
-is implied by these notes.
+Released September 10, 2026. Extension-store submissions remain separate from
+the npm package and GitHub release.
 
 ## Highlights
 
@@ -60,14 +60,14 @@ npm run install:claude
 npm run install:opencode
 ```
 
-The npm command after this expanded package is published is
+The npm command is
 `cadence-install-skill --agent <host>`, with `kimi`, `zcode`, `claude-code`, or
 `opencode` as the target. See the [agent guide](../../integrations/agents/README.md)
 for the exact discovery paths and invocation syntax. ZCode project installation
 is a UI import, not a guessed `.zcode/` project directory.
 
 The Codex integration and multi-agent follow-up are now merged on `main`.
-The npm release is still pending; merging source does not publish the package.
+The npm package includes these integrations. Model-provider setup remains separate.
 
 ## Validation before publishing
 

--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Cadence: catch robotic writing, write in a voice you choose</title>
 <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
-<meta name="description" content="Install Cadence in Codex, Kimi Code CLI, ZCode, Claude Code, or OpenCode. Recast prose in a chosen voice and verify edits with the same local detector. Source installers are available now; the v0.3.0 npm release is pending.">
+<meta name="description" content="Cadence v0.3.0 is available on npm. Install it in Codex, Kimi Code CLI, ZCode, Claude Code, or OpenCode. Recast prose in a chosen voice and verify edits with the same local detector.">
 <meta property="og:title" content="Cadence: catch robotic writing, write in a voice you choose">
-<meta property="og:description" content="One writing workflow across coding agents. Install from source, choose a voice, and measure before and after. The v0.3.0 npm release is pending.">
+<meta property="og:description" content="Cadence v0.3.0 is released. One writing workflow across coding agents: install from npm or source, choose a voice, and measure before and after.">
 <meta property="og:type" content="website">
 <script>document.documentElement.classList.remove('no-js');document.documentElement.classList.add('js');</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -664,7 +664,7 @@ Cadence de-slop  ·  <span style="color:var(--panel-good)">score 0/100  ·  grad
       <h2 id="agents-heading">Pick your agent. Keep your voice.</h2>
       <p>One shared skill, the same ten profiles, and a local detector. Use the model already configured in your host — Kimi, GLM, or another supported model. Cadence does not change endpoints, API keys, or approvals.</p>
     </div>
-    <p class="source-note" id="release-status"><strong>Available from source now.</strong> The <code>v0.3.0</code> integrations are merged on GitHub; the npm v0.3.0 package has not been published. Use a checkout for the commands below. <a href="https://github.com/wuisabel-gif/Cadence/blob/main/docs/releases/v0.3.0.md">Release notes and remaining sign-off</a>.</p>
+    <p class="source-note" id="release-status"><strong>v0.3.0 is released.</strong> Install from npm without cloning: <code>npx --package=cadence-deslop@0.3.0 cadence-install-skill --agent kimi</code>. Replace <code>kimi</code> with <code>codex</code>, <code>zcode</code>, <code>claude-code</code>, or <code>opencode</code>. The cards below use a source checkout. <a href="https://github.com/wuisabel-gif/Cadence/releases/tag/v0.3.0">Release notes and downloads</a>.</p>
     <div class="agent-start">
       <p>First, get a checkout. You need Node 18 or newer for the detector.</p>
       <pre class="codeblock"><code>git clone https://github.com/wuisabel-gif/Cadence.git
@@ -728,6 +728,10 @@ cd Cadence</code></pre>
       <p>One detector, more places to use it. Source updates and published releases are marked separately.</p>
     </div>
     <ul class="changelog reveal">
+      <li>
+        <span class="date">Sep 10, 2026</span>
+        <span class="entry"><span class="new">RELEASE</span> <b>v0.3.0 is on npm.</b> The package includes the shared agent installers, all ten voices, and the local detector. <a href="https://github.com/wuisabel-gif/Cadence/releases/tag/v0.3.0">Release notes and downloads</a>. GPU training remains experimental.</span>
+      </li>
       <li>
         <span class="date">Sep 7, 2026</span>
         <span class="entry"><span class="new">SOURCE</span> <b>Install once in your agent.</b> Codex, Kimi Code CLI, ZCode Agent, Claude Code, and OpenCode now share one skill, the ten voice profiles, and the same local detector. <a href="#agents">Choose an installer</a>. Your provider settings and existing project instructions stay untouched.</span>
@@ -817,7 +821,7 @@ cd Cadence</code></pre>
 <span class="pr">&gt;</span> Use Cadence to list the available voices.
 <span class="pr">&gt;</span> Use Cadence to de-slop this draft.
 <span class="pr">&gt;</span> Use Cadence to write a 150-word intro in the counsel voice.</div>
-          <div class="status"><span class="v" data-source-version="0.3.0">v0.3.0 source</span> · ten seed voices · npm release pending</div>
+          <div class="status"><span class="v" data-source-version="0.3.0">v0.3.0</span> · ten seed voices · available on npm</div>
         </div>
         <div class="steps reveal">
           <div class="callout"><b>This plugin route is for Claude Code.</b> It is separate from the standalone agent skills. Regular claude.ai chats use the uploadable skill bundle, and can verify scores only when code execution is available.</div>
@@ -890,7 +894,7 @@ cd Cadence</code></pre>
       <a class="mark" href="#top"><svg class="brandmark" viewBox="0 0 200 200" fill="none" aria-hidden="true"><rect x="21" y="51" width="22" height="107" rx="11" fill="#2348a1"/><rect x="55" y="96" width="22" height="62" rx="11" fill="#2348a1"/><rect x="89" y="38" width="22" height="120" rx="11" fill="#2348a1"/><rect x="123" y="68" width="22" height="90" rx="11" fill="#db332c"/><rect x="157" y="108" width="22" height="50" rx="11" fill="#2348a1"/></svg>Cadence</a>
       <p>A detector for the AI fingerprint, and a voice to write toward instead. Diagnose first, then fix, then verify the result.</p>
       <div class="builtwith">Built with Cadence: <a href="https://github.com/wuisabel-gif/linkedin-message-drafter">linkedin-message-drafter</a>, <a href="https://github.com/wuisabel-gif/readme-auto-update">readme-auto-update</a>, <a href="https://github.com/wuisabel-gif/elegance">elegance</a>.</div>
-      <div class="meta"><span data-source-version="0.3.0">v0.3.0 source</span> · npm release pending · plain Node · © 2026 <a href="https://github.com/wuisabel-gif">Isabel Wu</a> · MIT</div>
+      <div class="meta"><span data-source-version="0.3.0">v0.3.0</span> · available on npm · plain Node · © 2026 <a href="https://github.com/wuisabel-gif">Isabel Wu</a> · MIT</div>
     </div>
     <pre class="tree">cadence/
 ├── .claude-plugin/

--- a/integrations/agents/README.md
+++ b/integrations/agents/README.md
@@ -74,8 +74,7 @@ without local execution are not covered by this installer.
 
 ## npm and portable builds
 
-These npm commands require the expanded v0.3.0 package to be published. Until
-then, use the checkout commands above:
+The v0.3.0 package includes these installers. No checkout is needed:
 
 ```bash
 npx --package=cadence-deslop@0.3.0 cadence-install-skill --agent kimi

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -30,11 +30,9 @@ npm run install:codex -- --project /path/to/project
 That writes `<project>/.agents/skills/cadence/`. Choose one scope; you do not need
 both. When a path has spaces, quote it.
 
-## Install from npm after v0.3.0 is published
+## Install from npm
 
-The installer is included in the v0.3.0 package being prepared. These commands
-will work once that version has been published; use the checkout method above
-until then.
+The installer is included in the v0.3.0 package. Install once with npm:
 
 ```bash
 npx --package=cadence-deslop@0.3.0 cadence-install-codex

--- a/tests/website.test.mjs
+++ b/tests/website.test.mjs
@@ -43,6 +43,10 @@ test('site source version and publication notice match release preparation metad
     assert.ok(notice.includes(`npm v${pkg.version} package has not been published`));
     assert.match(notice, /Available from source now/);
     assert.ok(!html.includes(`cadence-deslop@${pkg.version}`), 'do not offer an unpublished npm version');
+  } else {
+    assert.ok(notice.includes(`v${pkg.version} is released`));
+    assert.ok(notice.includes(`cadence-deslop@${pkg.version}`));
+    assert.ok(!notice.includes('has not been published'));
   }
 });
 


### PR DESCRIPTION
Finalize September 10 release metadata and website publication status. All release checks pass. Do not merge until npm publication is confirmed. Experimental GPU training and manual client-validation caveats remain documented.